### PR TITLE
Add upstream sync script.

### DIFF
--- a/dev-tools/sync-upstream.sh
+++ b/dev-tools/sync-upstream.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Sync master of github clone with canonical upstream.
+#
+
+set -e
+set -u
+
+UPSTREAM_URL="https://github.com/php/pecl-file_formats-yaml.git"
+UPSTREAM=upstream
+MASTER=master
+
+MY_UPSTREAM=$(git remote show ${UPSTREAM} 2>/dev/null |
+    grep "Fetch URL"|awk '{print $3}')
+
+if [[ -z ${MY_UPSTREAM} ]]; then
+  echo "Adding remote ${UPSTREAM} ${UPSTREAM_URL}"
+  git remote add ${UPSTREAM} ${UPSTREAM_URL}
+  MY_UPSTREAM=${UPSTREAM_URL}
+fi
+
+if [[ ${MY_UPSTREAM} != ${UPSTREAM_URL} ]]; then
+  echo "Remote ${UPSTREAM} not tracking expected ${UPSTREAM_URL}"
+  echo "Cowardly refusing to continue"
+  exit 1
+fi
+
+set -x
+
+git fetch ${UPSTREAM} -pv
+git checkout ${MASTER}
+git merge --ff-only ${UPSTREAM}/master


### PR DESCRIPTION
Helper script to setup clone to sync master branch with an upstream remote.
Default setup to keep a fork in sync with the github public clone. Very handy
for tracking the master in a github clone that can then be used to stage
working branches and submit pull requests.
