### PR TITLE
Protect against segmentation fault with merge keys

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -429,8 +429,9 @@ static zval *handle_mapping(parser_state_t *state TSRMLS_DC)
 		}
 
 		/* check for '<<' and handle merge */
-		if (IS_NOT_QUOTED_OR_TAG_IS(key_event, YAML_MERGE_TAG) && 
-				STR_EQ("<<", key_str)) {
+		if (IS_NOT_QUOTED_OR_TAG_IS(key_event, YAML_MERGE_TAG) &&
+				STR_EQ("<<", key_str) &&
+				Z_TYPE_P(value) == IS_ARRAY) {
 			/* zend_hash_merge */
 			/*
 			 * value is either a single ref or a simple array of refs

--- a/tests/bug_64019.phpt
+++ b/tests/bug_64019.phpt
@@ -1,0 +1,49 @@
+--TEST--
+Test PECL bug #64019
+--SKIPIF--
+<?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--FILE--
+<?php
+$yaml_code = <<<YAML
+configAnchors:
+  - &wrongAnchor:   # This last colon (:) makes the script die
+    configKey: configValue
+
+config:
+  <<: *wrongAnchor
+YAML;
+
+var_dump(yaml_parse($yaml_code));
+
+$yaml_code = <<<YAML
+config:
+  <<:
+YAML;
+
+var_dump(yaml_parse($yaml_code));
+?>
+--EXPECT--
+array(2) {
+  ["configAnchors"]=>
+  array(1) {
+    [0]=>
+    array(2) {
+      [""]=>
+      NULL
+      ["configKey"]=>
+      string(11) "configValue"
+    }
+  }
+  ["config"]=>
+  array(1) {
+    ["<<"]=>
+    NULL
+  }
+}
+array(1) {
+  ["config"]=>
+  array(1) {
+    ["<<"]=>
+    NULL
+  }
+}


### PR DESCRIPTION
Previously any merge key found in a mapping was expected to have a RHS of an
array. This patch adds a validation that the RHS is indeed an array before
attempting to merge the RHS values into the current mapping.

Bug: 64019
