### PR TITLE
Fix detection of sexagesimal numbers

### DIFF
--- a/detect.c
+++ b/detect.c
@@ -327,6 +327,9 @@ scalar_is_numeric(const char *value, size_t length, long *lval,
 		} else if (*value == '.') {
 			goto check_float;
 
+		} else if (*value == ':') {
+			goto check_sexa;
+
 		} else {
 			goto not_numeric;
 		}
@@ -359,7 +362,7 @@ scalar_is_numeric(const char *value, size_t length, long *lval,
 		/* sexagecimal */
 
 check_sexa:
-		while (value < end - 2) {
+		while (value < end) {
 			if (*value == '.') {
 				type = Y_SCALAR_IS_FLOAT | Y_SCALAR_IS_SEXAGECIMAL;
 				goto check_float;
@@ -370,7 +373,8 @@ check_sexa:
 			}
 
 			*ptr++ = *value++;
-			if (*(value + 1) == ':') {
+			if (*(value + 1) == ':' || *(value + 1) == '.' ||
+					(value + 1) == end) {
 				if (*value >= '0' && *value <= '9') {
 					*ptr++ = *value++;
 

--- a/tests/bug_61923.phpt
+++ b/tests/bug_61923.phpt
@@ -1,0 +1,94 @@
+--TEST--
+Test PECL bug #61923
+--SKIPIF--
+<?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--FILE--
+<?php
+$yaml_code = <<<YAML
+---
+strings:
+  - '1:0'
+  - '0:1'
+  - '1:0:0'
+  - '+1:0:0'
+  - '-1:0:0'
+  - ':01'
+  - ':1'
+  - '18:53:17.00037'
+numbers:
+  - 1:0
+  - 0:1
+  - 1:0:0
+  - +1:0:0
+  - -1:0:0
+  - :01
+  - :1
+  - 18:53:17.00037
+YAML;
+
+$parsed = yaml_parse($yaml_code);
+var_dump($parsed);
+var_dump(yaml_emit($parsed));
+?>
+--EXPECT--
+array(2) {
+  ["strings"]=>
+  array(8) {
+    [0]=>
+    string(3) "1:0"
+    [1]=>
+    string(3) "0:1"
+    [2]=>
+    string(5) "1:0:0"
+    [3]=>
+    string(6) "+1:0:0"
+    [4]=>
+    string(6) "-1:0:0"
+    [5]=>
+    string(3) ":01"
+    [6]=>
+    string(2) ":1"
+    [7]=>
+    string(14) "18:53:17.00037"
+  }
+  ["numbers"]=>
+  array(8) {
+    [0]=>
+    int(60)
+    [1]=>
+    int(1)
+    [2]=>
+    int(3600)
+    [3]=>
+    int(3600)
+    [4]=>
+    int(-3600)
+    [5]=>
+    int(1)
+    [6]=>
+    int(1)
+    [7]=>
+    float(67997.00037)
+  }
+}
+string(162) "---
+strings:
+- "1:0"
+- "0:1"
+- "1:0:0"
+- "+1:0:0"
+- "-1:0:0"
+- ":01"
+- ":1"
+- "18:53:17.00037"
+numbers:
+- 60
+- 1
+- 3600
+- 3600
+- -3600
+- 1
+- 1
+- 67997.000370
+...
+"


### PR DESCRIPTION
Sexagesimal (base 60) numbers of certain formats were not being detected
properly. Specifically values with a leading 0 or only one digit following the
`:` delimiter were not detected on parse or emit as being numeric types.

Bug: 61923
