### PR TITLE
Ensure that strings are valid UTF-8 before calling libyaml

### DIFF
--- a/tests/bug_61770.phpt
+++ b/tests/bug_61770.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Test PECL bug #61770
+--SKIPIF--
+<?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--FILE--
+<?php
+var_dump(yaml_emit("\xc2"));
+?>
+--EXPECTF--
+Warning: yaml_emit(): Invalid UTF-8 sequence in argument in %sbug_61770.php on line 2
+bool(false)


### PR DESCRIPTION
Libyaml has a crash bug that can be triggered by invalid UTF-8 input. This
patch adds a UTF-8 encoding validator function borrowed from
ext/standard/html.c to validate strings encoding before calling libyaml.

Bug: 61770
