### PR TITLE
Fix schema validation for package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -254,6 +254,7 @@
     <release>beta</release>
     <api>beta</api>
    </stability>
+   <date>2010-02-06</date>
    <notes>
     First release from new hosting at svn.php.net via pecl.php.net
    </notes>


### PR DESCRIPTION
Apparently I messed up the package.xml file ~5 years ago in such a way that
pyrus has never been able to install the extension. This was reported ~3 years
ago to pyrus (pyrus/Pyrus#95) but I never saw an upstream bug report.