### PR TITLE
Resolve quoted and non-specific scalars as strings

### DIFF
--- a/detect.c
+++ b/detect.c
@@ -112,8 +112,10 @@ scalar_is_null(const char *value, size_t length, const yaml_event_t *event)
 	}
 
 	if (NULL == event || event->data.scalar.plain_implicit) {
-		if ((length == 1 && *value == '~') || length == 0 ||
-				STR_EQ("NULL", value) || STR_EQ("Null", value) ||
+		if (length == 0 ||
+				(length == 1 && *value == '~') ||
+				STR_EQ("NULL", value) ||
+				STR_EQ("Null", value) ||
 				STR_EQ("null", value)) {
 			return 1;
 		}
@@ -138,19 +140,27 @@ scalar_is_bool(const char *value, size_t length, const yaml_event_t *event)
 	/* TODO: add ini setting to turn 'y'/'n' checks on/off */
 	if (NULL == event || IS_NOT_QUOTED_OR_TAG_IS((*event), YAML_BOOL_TAG)) {
 		if ((length == 1 && (*value == 'Y' || *value == 'y')) ||
-				STR_EQ("YES", value) || STR_EQ("Yes", value) ||
-				STR_EQ("yes", value) || STR_EQ("TRUE", value) ||
-				STR_EQ("True", value) || STR_EQ("true", value) ||
-				STR_EQ("ON", value) || STR_EQ("On", value) ||
+				STR_EQ("YES", value) ||
+				STR_EQ("Yes", value) ||
+				STR_EQ("yes", value) ||
+				STR_EQ("TRUE", value) ||
+				STR_EQ("True", value) ||
+				STR_EQ("true", value) ||
+				STR_EQ("ON", value) ||
+				STR_EQ("On", value) ||
 				STR_EQ("on", value)) {
 			return 1;
 		}
 
 		if ((length == 1 && (*value == 'N' || *value == 'n')) ||
-				STR_EQ("NO", value) || STR_EQ("No", value) || 
-				STR_EQ("no", value) || STR_EQ("FALSE", value) || 
-				STR_EQ("False", value) || STR_EQ("false", value) ||
-				STR_EQ("OFF", value) || STR_EQ("Off", value) ||
+				STR_EQ("NO", value) ||
+				STR_EQ("No", value) ||
+				STR_EQ("no", value) ||
+				STR_EQ("FALSE", value) ||
+				STR_EQ("False", value) ||
+				STR_EQ("false", value) ||
+				STR_EQ("OFF", value) ||
+				STR_EQ("Off", value) ||
 				STR_EQ("off", value)) {
 			return 0;
 		}
@@ -202,7 +212,8 @@ scalar_is_numeric(const char *value, size_t length, long *lval,
 	}
 
 	/* not a number */
-	if (STR_EQ(".NAN", value) || STR_EQ(".NaN", value) ||
+	if (STR_EQ(".NAN", value) ||
+			STR_EQ(".NaN", value) ||
 			STR_EQ(".nan", value)) {
 		type = Y_SCALAR_IS_FLOAT | Y_SCALAR_IS_NAN;
 		goto finish;
@@ -222,7 +233,8 @@ scalar_is_numeric(const char *value, size_t length, long *lval,
 	}
 
 	/* infinity */
-	if (STR_EQ(".INF", value) || STR_EQ(".Inf", value) ||
+	if (STR_EQ(".INF", value) ||
+			STR_EQ(".Inf", value) ||
 			STR_EQ(".inf", value)) {
 		type = Y_SCALAR_IS_FLOAT;
 		type |= (negative ? Y_SCALAR_IS_INFINITY_N : Y_SCALAR_IS_INFINITY_P);
@@ -611,13 +623,17 @@ int scalar_is_timestamp(const char *value, size_t length)
 	const char *end = value + length;
 	const char *pos1, *pos2;
 
+	if (ptr == NULL || ptr == end) {
+		return 0;
+	}
+
 	/* skip leading space */
 	ts_skip_space();
 
 	/* check 4 digit year and separator */
 	pos1 = pos2 = ptr;
 	ts_skip_number();
-	if (ptr == pos1 || ptr == end || ptr - pos2 != 4 || *ptr != '-') {
+	if (ptr == pos1 || ptr == end || ptr - pos1 != 4 || *ptr != '-') {
 		return 0;
 	}
 
@@ -646,8 +662,11 @@ int scalar_is_timestamp(const char *value, size_t length)
 	if (*ptr == 'T' || *ptr == 't') {
 		ptr++;
 
-	} else {
+	} else if (*ptr == ' ' || *ptr == '\t') {
 		ts_skip_space();
+
+	} else {
+		return 0;
 	}
 
 	/* check 1 or 2 digit hour and separator */
@@ -784,5 +803,5 @@ static double eval_sexagesimal_d(double dval, const char *sg, const char *eos)
  * c-basic-offset: 4
  * End:
  * vim600: noet sw=4 ts=4 fdm=marker
- * vim<600: noet sw=4 ts=4 
+ * vim<600: noet sw=4 ts=4
  */

--- a/dev-tools/test-build.sh
+++ b/dev-tools/test-build.sh
@@ -21,6 +21,7 @@ hash phpenv &>/dev/null || {
 make distclean &>/dev/null || true
 phpenv local $1 &&
 phpize &&
-CC=colorgcc CFLAGS="-Wall -fno-strict-aliasing" ./configure --with-yaml &&
+CC=colorgcc CFLAGS="-Wall -fno-strict-aliasing -g3" \
+  ./configure --with-yaml --enable-debug &&
 make clean all &&
 TEST_PHP_EXECUTABLE=$(command -v php) ${SCRIPT_DIR}/test.sh || exit $?

--- a/parse.c
+++ b/parse.c
@@ -821,7 +821,7 @@ zval *eval_scalar(yaml_event_t event,
 
 
 /* {{{ eval_scalar_with_callbacks()
- * Convert a scalar node to the proper PHP data type using user supplied input 
+ * Convert a scalar node to the proper PHP data type using user supplied input
  * filters if available.
  */
 zval *eval_scalar_with_callbacks(yaml_event_t event,
@@ -1041,14 +1041,14 @@ eval_timestamp(zval **zpp, const char *ts, size_t ts_len TSRMLS_DC)
 
 			while (src < end && *src != '.') {
 				if (src + 1 < end &&
-						(*(src - 1) >= '0' && *(src - 1) <= '9') && 
-						(*src == 'T' || *src == 't') && 
+						(*(src - 1) >= '0' && *(src - 1) <= '9') &&
+						(*src == 'T' || *src == 't') &&
 						(*(src + 1) >= '0' && *(src + 1) <= '9')) {
 					src++;
 					*dst++ = ' ';
 
 				} else if (*src == ':' && src > ts + 2 && (
-						((*(src - 2) == '+' || *(src - 2) == '-') && 
+						((*(src - 2) == '+' || *(src - 2) == '-') &&
 						 (*(src - 1) >= '0' || *(src - 1) <= '5')) ||
 						((*(src - 3) == '+' || *(src - 3) == '-') &&
 						 (*(src - 2) >= '0' || *(src - 2) <= '5') &&

--- a/php_yaml_int.h
+++ b/php_yaml_int.h
@@ -64,9 +64,10 @@ typedef struct y_emit_state_s {
 
 /* {{{ ext/yaml macros
 */
-#define YAML_BINARY_TAG     "tag:yaml.org,2002:binary"
-#define YAML_MERGE_TAG      "tag:yaml.org,2002:merge"
-#define YAML_PHP_TAG        "!php/object"
+#define YAML_BINARY_TAG      "tag:yaml.org,2002:binary"
+#define YAML_MERGE_TAG       "tag:yaml.org,2002:merge"
+#define YAML_PHP_TAG         "!php/object"
+#define YAML_NONSPECIFIC_TAG "!"
 
 #define Y_SCALAR_IS_NOT_NUMERIC 0x00
 #define Y_SCALAR_IS_INT         0x10
@@ -90,16 +91,25 @@ typedef struct y_emit_state_s {
 #endif
 
 #define STR_EQ(a, b)\
-	(0 == strcmp(a, b))
+	(a != NULL && b != NULL && 0 == strcmp(a, b))
 
 #define SCALAR_TAG_IS(event, name) \
-	STR_EQ((const char *)event.data.scalar.tag, name)
+	STR_EQ(name, (const char *)event.data.scalar.tag)
+
+#define IS_NOT_IMPLICIT(event) \
+	(!event.data.scalar.quoted_implicit && !event.data.scalar.plain_implicit)
 
 #define IS_NOT_IMPLICIT_AND_TAG_IS(event, name) \
-	(!event.data.scalar.quoted_implicit && !event.data.scalar.plain_implicit && SCALAR_TAG_IS(event, name))
+	(IS_NOT_IMPLICIT(event) && SCALAR_TAG_IS(event, name))
+
+#define IS_NOT_QUOTED(event) \
+	(YAML_PLAIN_SCALAR_STYLE == event.data.scalar.style || YAML_ANY_SCALAR_STYLE == event.data.scalar.style)
 
 #define IS_NOT_QUOTED_OR_TAG_IS(event, name) \
-	((YAML_PLAIN_SCALAR_STYLE == event.data.scalar.style || YAML_ANY_SCALAR_STYLE == event.data.scalar.style) && (event.data.scalar.plain_implicit || SCALAR_TAG_IS(event, name)))
+	(IS_NOT_QUOTED(event) && (event.data.scalar.plain_implicit || SCALAR_TAG_IS(event, name)))
+
+#define SCALAR_IS_QUOTED(event) \
+	(YAML_SINGLE_QUOTED_SCALAR_STYLE == event.data.scalar.style || YAML_DOUBLE_QUOTED_SCALAR_STYLE == event.data.scalar.style)
 
 /* }}} */
 

--- a/tests/bug_69465.phpt
+++ b/tests/bug_69465.phpt
@@ -1,0 +1,53 @@
+--TEST--
+Test PECL bug #69465
+--SKIPIF--
+<?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--INI--
+yaml.decode_timestamp=1
+date.timezone=UTC
+--FILE--
+<?php
+$yaml_code = <<<YAML
+date1: 2015-05-15
+date2: "2015-05-15"
+date3: ! 2015-05-15
+bool1: true
+bool2: "true"
+bool3: ! true
+int1: 1
+int2: "1"
+int3: ! 1
+float1: 1.5
+float2: "1.5"
+float3: ! 1.5
+YAML;
+
+var_dump(yaml_parse($yaml_code));
+?>
+--EXPECT--
+array(12) {
+  ["date1"]=>
+  int(1431648000)
+  ["date2"]=>
+  string(10) "2015-05-15"
+  ["date3"]=>
+  string(10) "2015-05-15"
+  ["bool1"]=>
+  bool(true)
+  ["bool2"]=>
+  string(4) "true"
+  ["bool3"]=>
+  string(4) "true"
+  ["int1"]=>
+  int(1)
+  ["int2"]=>
+  string(1) "1"
+  ["int3"]=>
+  string(1) "1"
+  ["float1"]=>
+  float(1.5)
+  ["float2"]=>
+  string(3) "1.5"
+  ["float3"]=>
+  string(3) "1.5"
+}


### PR DESCRIPTION
If a scalar is quoted or explicitly marked with the "!" non-specific tag then
it typically should be resolved by the parser as a string even if the contents
could otherwise match an implicit casting rule (bool, int, float, timestamp).

Bug: 69465