### PR TITLE
Win64 fixes

### DIFF
--- a/detect.c
+++ b/detect.c
@@ -54,7 +54,7 @@
 
 /* {{{ local prototypes
  */
-static long eval_sexagesimal_l(long lval, const char *sg, const char *eos);
+static zend_long eval_sexagesimal_l(zend_long lval, const char *sg, const char *eos);
 
 static double eval_sexagesimal_d(double dval, const char *sg, const char *eos);
 
@@ -68,7 +68,7 @@ const char *detect_scalar_type(const char *value, size_t length,
 		const yaml_event_t *event)
 {
 	int flags = 0;
-	long lval = 0;
+	zend_long lval = 0;
 	double dval = 0.0;
 
 	/* is value a null? */
@@ -186,7 +186,7 @@ scalar_is_bool(const char *value, size_t length, const yaml_event_t *event)
  * specification is found at http://yaml.org/type/int.html.
  */
 int
-scalar_is_numeric(const char *value, size_t length, long *lval,
+scalar_is_numeric(const char *value, size_t length, zend_long *lval,
 		double *dval, char **str)
 {
 	const char *end = value + length;
@@ -747,7 +747,7 @@ int scalar_is_timestamp(const char *value, size_t length)
 /* {{{ eval_sexagesimal_l()
  * Convert a base 60 number to a long
  */
-static long eval_sexagesimal_l(long lval, const char *sg, const char *eos)
+static zend_long eval_sexagesimal_l(zend_long lval, const char *sg, const char *eos)
 {
 	const char *ep;
 

--- a/emit.c
+++ b/emit.c
@@ -461,10 +461,10 @@ static int y_write_array(
 	zval *elm;
 	int array_type;
 	zval key_zval;
-	ulong kidx;
+	zend_ulong kidx;
 	zend_string *kstr;
 	HashTable *tmp_ht;
-	long recursive_idx = -1;
+	zend_long recursive_idx = -1;
 	char *anchor = { 0 };
 	size_t anchor_size;
 
@@ -489,7 +489,7 @@ static int y_write_array(
 	 *   if ht->nApplyCount > 0:
 	 *     emit a ref
 	 */
-	recursive_idx = y_search_recursive(state, (unsigned long) ht TSRMLS_CC);
+	recursive_idx = y_search_recursive(state, (zend_ulong) ht TSRMLS_CC);
 	if (-1 != recursive_idx) {
 		/* create anchor to refer to this structure */
 		anchor_size = snprintf(anchor, 0, "refid%ld", recursive_idx + 1);

--- a/emit.c
+++ b/emit.c
@@ -176,7 +176,7 @@ static void y_scan_recursion(const y_emit_state_t *state, zval *data TSRMLS_DC)
 
 	if (ZEND_HASH_APPLY_PROTECTION(ht) && ht->u.v.nApplyCount > 0) {
 		zval tmp;
-		ZVAL_LONG(&tmp, (unsigned long) ht);
+		ZVAL_LONG(&tmp, (zend_ulong) ht);
 
 		/* we've seen this before, so record address */
 		zend_hash_next_index_insert(state->recursive, &tmp);

--- a/emit.c
+++ b/emit.c
@@ -56,8 +56,8 @@ static int y_event_emit(
 static void y_handle_emitter_error(const y_emit_state_t *state TSRMLS_DC);
 static int y_array_is_sequence(HashTable *ht TSRMLS_DC);
 static void y_scan_recursion(const y_emit_state_t *state, zval *data TSRMLS_DC);
-static long y_search_recursive(
-		const y_emit_state_t *state, const unsigned long addr TSRMLS_DC);
+static zend_long y_search_recursive(
+		const y_emit_state_t *state, const zend_ulong addr TSRMLS_DC);
 
 static int y_write_zval(
 		const y_emit_state_t *state, zval *data, yaml_char_t *tag TSRMLS_DC);
@@ -137,7 +137,7 @@ static void y_handle_emitter_error(const y_emit_state_t *state TSRMLS_DC)
  */
 static int y_array_is_sequence(HashTable *ht TSRMLS_DC)
 {
-	ulong kidx, idx;
+	zend_ulong kidx, idx;
 	zend_string *str_key;
 
 	idx = 0;
@@ -203,12 +203,12 @@ static void y_scan_recursion(const y_emit_state_t *state, zval *data TSRMLS_DC)
 /* {{{ y_search_recursive()
  * Search the recursive state hash for an address
  */
-static long y_search_recursive(
-		const y_emit_state_t *state, const unsigned long addr TSRMLS_DC)
+static zend_long y_search_recursive(
+		const y_emit_state_t *state, const zend_ulong addr TSRMLS_DC)
 {
  	zval *entry;
-   	ulong num_key;
-	unsigned long found;
+   	zend_ulong num_key;
+	zend_ulong found;
 
 	ZEND_HASH_FOREACH_NUM_KEY_VAL(state->recursive, num_key, entry) {
 		found = Z_LVAL_P(entry);

--- a/parse.c
+++ b/parse.c
@@ -98,7 +98,7 @@ static int eval_timestamp(zval **zpp, const char *ts, size_t ts_len TSRMLS_DC);
 /* {{{ php_yaml_read_all()
  * Process events from yaml parser
  */
-void php_yaml_read_all(parser_state_t *state, long *ndocs, zval *retval TSRMLS_DC)
+void php_yaml_read_all(parser_state_t *state, zend_long *ndocs, zval *retval TSRMLS_DC)
 {
 	zval doc;
 	int code = Y_PARSER_CONTINUE;
@@ -165,7 +165,7 @@ void php_yaml_read_all(parser_state_t *state, long *ndocs, zval *retval TSRMLS_D
  * Read a particular document from the parser's document stream.
  */
 void php_yaml_read_partial(
-		parser_state_t *state, long pos, long *ndocs, zval *retval TSRMLS_DC)
+		parser_state_t *state, zend_long pos, zend_long *ndocs, zval *retval TSRMLS_DC)
 {
 	int code = Y_PARSER_CONTINUE;
 
@@ -674,7 +674,7 @@ void eval_scalar(yaml_event_t event,
 			(event.data.scalar.plain_implicit ||
 			 SCALAR_TAG_IS(event, YAML_INT_TAG) ||
 			 SCALAR_TAG_IS(event, YAML_FLOAT_TAG))) {
-		long lval = 0;
+		zend_long lval = 0;
 		double dval = 0.0;
 
 		flags = scalar_is_numeric(

--- a/php_yaml.h
+++ b/php_yaml.h
@@ -76,12 +76,12 @@ extern zend_module_entry yaml_module_entry;
 
 ZEND_BEGIN_MODULE_GLOBALS(yaml)
 	zend_bool decode_binary;
-	long decode_timestamp;
+	zend_long decode_timestamp;
 	zend_bool decode_php;
 	zval *timestamp_decoder;
 	zend_bool output_canonical;
-	long output_indent;
-	long output_width;
+	zend_long output_indent;
+	zend_long output_width;
 #ifdef IS_UNICODE
 	UConverter *orig_runtime_encoding_conv;
 #endif

--- a/php_yaml_int.h
+++ b/php_yaml_int.h
@@ -115,10 +115,10 @@ typedef struct y_emit_state_s {
 
 /* {{{ ext/yaml prototypes
 */
-void php_yaml_read_all(parser_state_t *state, long *ndocs, zval *retval TSRMLS_DC);
+void php_yaml_read_all(parser_state_t *state, zend_long *ndocs, zval *retval TSRMLS_DC);
 
 void php_yaml_read_partial(
-		parser_state_t *state, long pos, long *ndocs, zval *retval TSRMLS_DC);
+		parser_state_t *state, zend_long pos, zend_long *ndocs, zval *retval TSRMLS_DC);
 
 void eval_scalar(yaml_event_t event,
 		HashTable * callbacks, zval *retval TSRMLS_DC);
@@ -136,7 +136,7 @@ int scalar_is_bool(
 		const char *value, size_t length, const yaml_event_t *event);
 
 int scalar_is_numeric(
-		const char *value, size_t length, long *lval, double *dval, char **str);
+		const char *value, size_t length, zend_long *lval, double *dval, char **str);
 
 int scalar_is_timestamp(const char *value, size_t length);
 

--- a/yaml.c
+++ b/yaml.c
@@ -690,11 +690,10 @@ PHP_FUNCTION(yaml_emit_file)
 	yaml_emitter_t emitter = { 0 };
 
 #ifdef IS_UNICODE
-	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s&z/|ssa/",
-			&filename, &filename_len,
+	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "S&z/|SSa/",
+			&filename
 			ZEND_U_CONVERTER(UG(filesystem_encoding_conv)), &data,
-			&encoding, &encoding_len, &linebreak, &zcallbacks,
-			&linebreak_len)) {
+			&encoding, &linebreak, &zcallbacks)) {
 		return;
 	}
 #else
@@ -723,7 +722,7 @@ PHP_FUNCTION(yaml_emit_file)
 	yaml_emitter_set_canonical(&emitter, YAML_G(output_canonical));
 	yaml_emitter_set_indent(&emitter, YAML_G(output_indent));
 	yaml_emitter_set_width(&emitter, YAML_G(output_width));
-	yaml_emitter_set_unicode(&emitter, YAML_ANY_ENCODING != encoding);
+	yaml_emitter_set_unicode(&emitter, strncasecmp("utf-8", ZSTR_VAL(encoding), ZSTR_LEN(encoding) > sizeof("utf-8") ? sizeof("utf-8") : ZSTR_LEN(encoding)));
 
 	RETVAL_BOOL((SUCCESS == php_yaml_write_impl(
 			&emitter, data, YAML_ANY_ENCODING, callbacks TSRMLS_CC)));

--- a/yaml.c
+++ b/yaml.c
@@ -722,7 +722,7 @@ PHP_FUNCTION(yaml_emit_file)
 	yaml_emitter_set_canonical(&emitter, YAML_G(output_canonical));
 	yaml_emitter_set_indent(&emitter, YAML_G(output_indent));
 	yaml_emitter_set_width(&emitter, YAML_G(output_width));
-	yaml_emitter_set_unicode(&emitter, strncasecmp("utf-8", ZSTR_VAL(encoding), ZSTR_LEN(encoding) > sizeof("utf-8") ? sizeof("utf-8") : ZSTR_LEN(encoding)));
+	yaml_emitter_set_unicode(&emitter, encoding && 0 != strncasecmp("utf-8", ZSTR_VAL(encoding), ZSTR_LEN(encoding) > sizeof("utf-8") ? sizeof("utf-8") : ZSTR_LEN(encoding)));
 
 	RETVAL_BOOL((SUCCESS == php_yaml_write_impl(
 			&emitter, data, YAML_ANY_ENCODING, callbacks TSRMLS_CC)));

--- a/yaml.c
+++ b/yaml.c
@@ -350,13 +350,13 @@ static int php_yaml_check_callbacks(HashTable *callbacks TSRMLS_DC)
 PHP_FUNCTION(yaml_parse)
 {
 	zend_string *input;
-	long pos = 0;
+	zend_long pos = 0;
 	zval *zndocs = { 0 };
 	zval *zcallbacks = { 0 };
 
 	parser_state_t state;
 	zval yaml;
-	long ndocs = 0;
+	zend_long ndocs = 0;
 
 	memset(&state, 0, sizeof(state));
 	state.have_event = 0;
@@ -434,7 +434,7 @@ PHP_FUNCTION(yaml_parse_file)
 {
 	char *filename = { 0 };
 	int filename_len = 0;
-	long pos = 0;
+	zend_long pos = 0;
 	zval *zndocs = { 0 };
 	zval *zcallbacks = { 0 };
 
@@ -443,7 +443,7 @@ PHP_FUNCTION(yaml_parse_file)
 
 	parser_state_t state;
 	zval yaml;
-	long ndocs = 0;
+	zend_long ndocs = 0;
 
 	memset(&state, 0, sizeof(state));
 	state.have_event = 0;
@@ -535,7 +535,7 @@ PHP_FUNCTION(yaml_parse_url)
 {
 	char *url = { 0 };
 	int url_len = 0;
-	long pos = 0;
+	zend_long pos = 0;
 	zval *zndocs = { 0 };
 	zval *zcallbacks = { 0 };
 
@@ -545,7 +545,7 @@ PHP_FUNCTION(yaml_parse_url)
 
 	parser_state_t state;
 	zval yaml;
-	long ndocs = 0;
+	zend_long ndocs = 0;
 
 	memset(&state, 0, sizeof(state));
 	state.have_event = 0;
@@ -625,8 +625,8 @@ PHP_FUNCTION(yaml_parse_url)
 PHP_FUNCTION(yaml_emit)
 {
 	zval *data = { 0 };
-	long encoding = YAML_ANY_ENCODING;
-	long linebreak = YAML_ANY_BREAK;
+	zend_long encoding = YAML_ANY_ENCODING;
+	zend_long linebreak = YAML_ANY_BREAK;
 	zval *zcallbacks = { 0 };
 	HashTable *callbacks = { 0 };
 


### PR DESCRIPTION
Minimal set on fixes to get it worky on win64. Most are primitive. Though note the fix to the encoding arg in yaml_emit() - that should be probably also backported to the 5 branch.

Thanks.