### PR TITLE
Backport fixes from php7 branch

### DIFF
--- a/emit.c
+++ b/emit.c
@@ -686,13 +686,13 @@ static int y_write_object(
 				(yaml_char_t *) buf.c, buf.len,
 				0, 0, YAML_DOUBLE_QUOTED_SCALAR_STYLE);
 
-		smart_str_free(&buf);
 		if (!status) {
 			y_event_init_failed(&event);
 			status = FAILURE;
 		} else {
 			status = y_event_emit(state, &event TSRMLS_CC);
 		}
+		smart_str_free(&buf);
 	}
 
 	return status;

--- a/parse.c
+++ b/parse.c
@@ -55,16 +55,9 @@
 	memset(&state->event, 0, sizeof(yaml_event_t))
 
 
-#ifdef IS_UNICODE
-#define MAKE_ARRAY(var) \
-	MAKE_STD_ZVAL(var); \
-	array_init(var); \
-	Z_ARRVAL_P(var)->unicode = UG(unicode)
-#else
 #define MAKE_ARRAY(var) \
 	MAKE_STD_ZVAL(var); \
 	array_init(var)
-#endif
 /* }}} */
 
 
@@ -690,11 +683,7 @@ zval *eval_scalar(yaml_event_t event,
 	/* check for non-specific tag (treat as a string) */
 	if (SCALAR_TAG_IS(event, YAML_NONSPECIFIC_TAG) ||
 			event.data.scalar.quoted_implicit) {
-#ifdef IS_UNICODE
-		ZVAL_U_STRINGL(UG(utf8_conv), retval, value, length, ZSTR_DUPLICATE);
-#else
 		ZVAL_STRINGL(retval, value, length, 1);
-#endif
 		return retval;
 	}
 
@@ -805,11 +794,7 @@ zval *eval_scalar(yaml_event_t event,
 	}
 
 	/* others (treat as a string) */
-#ifdef IS_UNICODE
-	ZVAL_U_STRINGL(UG(utf8_conv), retval, value, length, ZSTR_DUPLICATE);
-#else
 	ZVAL_STRINGL(retval, value, length, 1);
-#endif
 
 	return retval;
 }
@@ -921,24 +906,6 @@ static char *convert_to_char(zval *zv TSRMLS_DC)
 	case IS_STRING:
 		str = estrndup(Z_STRVAL_P(zv), Z_STRLEN_P(zv));
 		break;
-
-#ifdef IS_UNICODE
-	case IS_UNICODE:
-		{
-			int len;
-			UErrorCode status = U_ZERO_ERROR;
-
-			zend_unicode_to_string_ex(UG(utf8_conv), &str, &len,
-					Z_USTRVAL_P(zv), Z_USTRLEN_P(zv), &status);
-			if (U_FAILURE(status)) {
-				if (str != NULL) {
-					efree(str);
-					str = NULL;
-				}
-			}
-		}
-		break;
-#endif
 
 #ifdef ZEND_ENGINE_2
 	case IS_OBJECT:
@@ -1100,11 +1067,7 @@ eval_timestamp(zval **zpp, const char *ts, size_t ts_len TSRMLS_DC)
 
 	} else {
 		zval_dtor(*zpp);
-#ifdef IS_UNICODE
-		ZVAL_U_STRINGL(UG(utf8_conv), *zpp, ts, ts_len, 1);
-#else
 		ZVAL_STRINGL(*zpp, ts, ts_len, 1);
-#endif
 		return SUCCESS;
 	}
 }

--- a/parse.c
+++ b/parse.c
@@ -943,6 +943,7 @@ static char *convert_to_char(zval *zv TSRMLS_DC)
 			} else {
 				str = NULL;
 			}
+			smart_str_free(&buf);
 		}
 		break;
 	}

--- a/php_yaml.h
+++ b/php_yaml.h
@@ -82,9 +82,6 @@ ZEND_BEGIN_MODULE_GLOBALS(yaml)
 	zend_bool output_canonical;
 	long output_indent;
 	long output_width;
-#ifdef IS_UNICODE
-	UConverter *orig_runtime_encoding_conv;
-#endif
 ZEND_END_MODULE_GLOBALS(yaml)
 
 ZEND_EXTERN_MODULE_GLOBALS(yaml)


### PR DESCRIPTION
- Remove IS_UNICODE (PHP6) support
- Free buffer after y_event_emit
- Always free smart_str buffer in convert_to_char