### PR TITLE
Disable decode_php by default

### DIFF
--- a/tests/bug_69616.phpt
+++ b/tests/bug_69616.phpt
@@ -2,6 +2,8 @@
 Test PECL bug #69616
 --SKIPIF--
 <?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--INI--
+yaml.decode_php=1
 --FILE--
 <?php
 $yaml_code = <<<YAML

--- a/tests/bug_69617.phpt
+++ b/tests/bug_69617.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test PECL bug #69617
+--SKIPIF--
+<?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--FILE--
+<?php
+$yaml_code = <<<YAML
+---
+a: !php/object "O:1:\"A\":1:{s:3:\"one\";i:1;}"
+...
+YAML;
+
+var_dump(yaml_parse($yaml_code));
+?>
+--EXPECT--
+array(1) {
+  ["a"]=>
+  string(26) "O:1:"A":1:{s:3:"one";i:1;}"
+}

--- a/tests/yaml_parse_007.phpt
+++ b/tests/yaml_parse_007.phpt
@@ -4,6 +4,8 @@ yaml_parse - serializable
 <?php
 if(!extension_loaded('yaml')) die('skip yaml n/a');
 ?>
+--INI--
+yaml.decode_php=1
 --FILE--
 <?php
 class A {

--- a/yaml.c
+++ b/yaml.c
@@ -77,7 +77,7 @@ PHP_INI_BEGIN()
 			decode_binary, zend_yaml_globals, yaml_globals)
 	STD_PHP_INI_ENTRY("yaml.decode_timestamp", "0", PHP_INI_ALL, OnUpdateLong,
 			decode_timestamp, zend_yaml_globals, yaml_globals)
-	STD_PHP_INI_ENTRY("yaml.decode_php", "1", PHP_INI_ALL, OnUpdateBool,
+	STD_PHP_INI_ENTRY("yaml.decode_php", "0", PHP_INI_ALL, OnUpdateBool,
 			decode_php, zend_yaml_globals, yaml_globals)
 	STD_PHP_INI_ENTRY("yaml.output_canonical", "0", PHP_INI_ALL, OnUpdateBool,
 			output_canonical, zend_yaml_globals, yaml_globals)
@@ -292,7 +292,7 @@ static PHP_GINIT_FUNCTION(yaml)
 {
 	yaml_globals->decode_binary = 0;
 	yaml_globals->decode_timestamp = 0;
-	yaml_globals->decode_php = 1;
+	yaml_globals->decode_php = 0;
 	yaml_globals->timestamp_decoder = NULL;
 	yaml_globals->output_canonical = 0;
 	yaml_globals->output_indent = 2;


### PR DESCRIPTION
Follow up to e89257d. The major version bump to 2.0.0 allows us to break
backwards compatibility, so change the default behavior for `!php/object`
handling to return a string rather than attempting to deserialize.

Bug: 69617