### PR TITLE
Fix result of tag callback to be copied to aliases.

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -401,6 +401,7 @@ static zval *handle_mapping(parser_state_t *state TSRMLS_DC)
 	if (NULL != src_event.data.mapping_start.anchor) {
 		/* record anchors in current alias table */
 		Z_ADDREF_P(retval);
+		Z_SET_ISREF_P(retval);
 		add_assoc_zval(state->aliases,
 				(char *) src_event.data.mapping_start.anchor,
 				retval);
@@ -500,6 +501,7 @@ static zval *handle_sequence (parser_state_t *state TSRMLS_DC) {
 	if (NULL != src_event.data.sequence_start.anchor) {
 		/* record anchors in current alias table */
 		Z_ADDREF_P(retval);
+		Z_SET_ISREF_P(retval);
 		add_assoc_zval(state->aliases,
 				(char *) src_event.data.sequence_start.anchor,
 				retval);
@@ -540,6 +542,7 @@ static zval *handle_scalar(parser_state_t *state TSRMLS_DC) {
 	if (NULL != retval && NULL != state->event.data.scalar.anchor) {
 		/* record anchors in current alias table */
 		Z_ADDREF_P(retval);
+		Z_SET_ISREF_P(retval);
 		add_assoc_zval(state->aliases,
 				(char *) state->event.data.scalar.anchor, retval);
 	}
@@ -570,7 +573,6 @@ static zval *handle_alias(parser_state_t *state TSRMLS_DC) {
 
 	/* add a reference to retval's internal counter */
 	Z_ADDREF_PP(retval);
-	Z_SET_ISREF_PP(retval);
 
 	return (*retval);
 }

--- a/tests/bug_alias_callback.phpt
+++ b/tests/bug_alias_callback.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Test tag callback of aliased list
+--SKIPIF--
+<?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--FILE--
+<?php
+$yaml_code = <<<YAML
+- &scalar !transform false
+- *scalar
+- &sequence !transform [false]
+- *sequence
+- &mapping !transform {k: false}
+- *mapping
+- &unused [true]
+YAML;
+
+function transform()
+{
+    return true;
+}
+
+var_dump(yaml_parse($yaml_code, 0, $count, array(
+    '!transform' => 'transform',
+)));
+?>
+--EXPECTF--
+array(7) {
+  [0]=>
+  &bool(true)
+  [1]=>
+  &bool(true)
+  [2]=>
+  &bool(true)
+  [3]=>
+  &bool(true)
+  [4]=>
+  &bool(true)
+  [5]=>
+  &bool(true)
+  [6]=>
+  array(1) {
+    [0]=>
+    bool(true)
+  }
+}


### PR DESCRIPTION
Passing a callback for !localtag makes it possible to transform data
while parsing. But when the transformation is used in conjunction
with &alias, *reference fails to refer the transformed value.