### PR TITLE
Fix result of tag callback to be copied to aliases. (PHP7)

### DIFF
--- a/tests/bug_64019.phpt
+++ b/tests/bug_64019.phpt
@@ -37,7 +37,7 @@ array(2) {
   ["config"]=>
   array(1) {
     ["<<"]=>
-    NULL
+    &NULL
   }
 }
 array(1) {

--- a/tests/yaml_parse_001.phpt
+++ b/tests/yaml_parse_001.phpt
@@ -74,7 +74,7 @@ array(8) {
   ["date"]=>
   int(980208000)
   ["bill-to"]=>
-  array(3) {
+  &array(3) {
     ["given"]=>
     string(5) "Chris"
     ["family"]=>
@@ -94,7 +94,7 @@ Suite #292
     }
   }
   ["ship-to"]=>
-  array(3) {
+  &array(3) {
     ["given"]=>
     string(5) "Chris"
     ["family"]=>

--- a/tests/yaml_parse_file_001.phpt
+++ b/tests/yaml_parse_file_001.phpt
@@ -15,7 +15,7 @@ array(8) {
   ["date"]=>
   int(980208000)
   ["bill-to"]=>
-  array(3) {
+  &array(3) {
     ["given"]=>
     string(5) "Chris"
     ["family"]=>
@@ -35,7 +35,7 @@ Suite #292
     }
   }
   ["ship-to"]=>
-  array(3) {
+  &array(3) {
     ["given"]=>
     string(5) "Chris"
     ["family"]=>


### PR DESCRIPTION
#22 (callback and !localtag) for PHP7

I ended up adding function `record_anchor_make_ref()`.
Also there are changes in tests/, which I suppose do not the matter much as they are mostly kind of aligning to what it is like in PHP5.