### PR TITLE
Add a php new ini setting of yaml.decode_bool

### DIFF
--- a/README
+++ b/README
@@ -72,6 +72,10 @@ ini settings:
   yaml.decode_php=0 for no serialized object parsing
   yaml.decode_php=1 for serialized object parsing
 
+  yaml.decode_bool=0 for no boolean words(on, off, yes, and no) parsing
+  yaml.decode_bool=1 for boolean words(on, off, yes, and no) parsing
+  yaml.decode_bool=2 for no abbreviated boolean words(y/n/Y/N) parsing
+
 /**
  * @param string $input String to parse as YAML document stream
  * @param int $pos Document to extract from stream (-1 for all, 0 for first, ...)

--- a/detect.c
+++ b/detect.c
@@ -137,7 +137,6 @@ scalar_is_null(const char *value, size_t length, const yaml_event_t *event)
 int
 scalar_is_bool(const char *value, size_t length, const yaml_event_t *event)
 {
-	/* TODO: add ini setting to turn 'y'/'n' checks on/off */
 	if (NULL == event || IS_NOT_QUOTED_OR_TAG_IS((*event), YAML_BOOL_TAG)) {
 		if ((length == 1 && (*value == 'Y' || *value == 'y')) ||
 				STR_EQ("YES", value) ||

--- a/parse.c
+++ b/parse.c
@@ -85,7 +85,7 @@ static char *convert_to_char(zval *zv TSRMLS_DC);
 
 static int eval_timestamp(zval **zpp, const char *ts, size_t ts_len TSRMLS_DC);
 
-static void eval_bool(zval *zv, int flags, const char *value, size_t length);
+static void eval_bool(zval *zv, int flags, const char *value, size_t length TSRMLS_DC);
 /* }}} */
 
 
@@ -696,7 +696,7 @@ zval *eval_scalar(yaml_event_t event,
 
 	/* check for bool */
 	if (-1 != (flags = scalar_is_bool(value, length, &event))) {
-		eval_bool(retval, flags, value, length);
+		eval_bool(retval, flags, value, length TSRMLS_CC);
 		return retval;
 	}
 
@@ -1019,7 +1019,7 @@ eval_timestamp(zval **zpp, const char *ts, size_t ts_len TSRMLS_DC)
  *  - yaml.decode_bool=2 for no abbreviated boolean words(y/n/Y/N) parsing
  */
 void
-eval_bool(zval *zv, int flags, const char *value, size_t length)
+eval_bool(zval *zv, int flags, const char *value, size_t length TSRMLS_DC)
 {
 	if (1L == YAML_G(decode_bool)) {
 		ZVAL_BOOL(zv, (zend_bool) flags);

--- a/php_yaml.h
+++ b/php_yaml.h
@@ -78,6 +78,7 @@ ZEND_BEGIN_MODULE_GLOBALS(yaml)
 	zend_bool decode_binary;
 	long decode_timestamp;
 	zend_bool decode_php;
+	long decode_bool;
 	zval *timestamp_decoder;
 	zend_bool output_canonical;
 	long output_indent;

--- a/tests/yaml_parse_009.phpt
+++ b/tests/yaml_parse_009.phpt
@@ -1,0 +1,61 @@
+--TEST--
+yaml_parse - bool treatment
+--SKIPIF--
+<?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--INI--
+yaml.decode_bool=1
+--FILE--
+<?php
+$data = <<<YAML
+canonical: y
+answer: NO
+logical: True
+option: on
+abbreviation: N
+YAML;
+
+var_dump(yaml_parse($data));
+
+ini_set('yaml.decode_bool', 0);
+var_dump(yaml_parse($data));
+
+ini_set('yaml.decode_bool', 2);
+var_dump(yaml_parse($data));
+?>
+--EXPECT--
+array(5) {
+  ["canonical"]=>
+  bool(true)
+  ["answer"]=>
+  bool(false)
+  ["logical"]=>
+  bool(true)
+  ["option"]=>
+  bool(true)
+  ["abbreviation"]=>
+  bool(false)
+}
+array(5) {
+  ["canonical"]=>
+  string(1) "y"
+  ["answer"]=>
+  string(2) "NO"
+  ["logical"]=>
+  string(4) "True"
+  ["option"]=>
+  string(2) "on"
+  ["abbreviation"]=>
+  string(1) "N"
+}
+array(5) {
+  ["canonical"]=>
+  string(1) "y"
+  ["answer"]=>
+  bool(false)
+  ["logical"]=>
+  bool(true)
+  ["option"]=>
+  bool(true)
+  ["abbreviation"]=>
+  string(1) "N"
+}

--- a/yaml.c
+++ b/yaml.c
@@ -68,6 +68,8 @@ PHP_INI_BEGIN()
 			decode_timestamp, zend_yaml_globals, yaml_globals)
 	STD_PHP_INI_ENTRY("yaml.decode_php", "1", PHP_INI_ALL, OnUpdateBool,
 			decode_php, zend_yaml_globals, yaml_globals)
+	STD_PHP_INI_ENTRY("yaml.decode_bool", "1", PHP_INI_ALL, OnUpdateLong,
+			decode_bool, zend_yaml_globals, yaml_globals)
 	STD_PHP_INI_ENTRY("yaml.output_canonical", "0", PHP_INI_ALL, OnUpdateBool,
 			output_canonical, zend_yaml_globals, yaml_globals)
 	STD_PHP_INI_ENTRY("yaml.output_indent", "2", PHP_INI_ALL, OnUpdateLong,
@@ -272,6 +274,7 @@ static PHP_GINIT_FUNCTION(yaml)
 	yaml_globals->output_canonical = 0;
 	yaml_globals->output_indent = 2;
 	yaml_globals->output_width = 80;
+	yaml_globals->decode_bool = 1;
 }
 /* }}} */
 


### PR DESCRIPTION
Hi,

I added new php ini setting to change a treatment for english boolean words like 'Yes' and 'No'.
The treatment can be changed as followings.
* When yaml.decode_bool=0, the parser recongnizes no english boolean words as bool('Yes' will be treated as string). 
* When yaml.decode_bool=1, the parser recongnizes english boolean words as bool. this is the default treatment.
* When yaml.decode_bool=2, the parser recongnizes english boolean words except abbreviation style(Y, y, N, and n) as bool.

The default treatment is same as now. 
I just wanted this feature 😄  
But if someone already work on this, I close this PR.

thanks!