### PR TITLE
Fix float parsing on Alpine

### DIFF
--- a/detect.c
+++ b/detect.c
@@ -568,7 +568,7 @@ finish:
 			break;
 
 		default:
-			*dval = atof(buf);
+			*dval = zend_strtod(buf, (const char **) NULL);
 			break;
 		}
 	}


### PR DESCRIPTION
Float values are sometimes inconsistently parsed on alpine. Using the zend
atod implementation fixes this.