### PR TITLE
Remove unused Git attributes ident

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,7 +1,3 @@
-dnl
-dnl $Id$
-dnl
-
 PHP_ARG_WITH(yaml, [whether to enable LibYAML suppot],
 [  --with-yaml[[=DIR]]       Enable LibYAML support.
                           DIR is the path to LibYAML install prefix])

--- a/config.w32
+++ b/config.w32
@@ -1,4 +1,3 @@
-// $Id$
 // vim:ft=javascript
 
 ARG_WITH("yaml", "The YAML parser and emitter PHP extension", "no");


### PR DESCRIPTION
The $Id$ keywords were used in Subversion where they can be substituted
with filename, last revision number change, last changed date, and last
user who changed it.

In Git this functionality is different and can be done with Git attribute
ident. These need to be defined manually for each file in the
.gitattributes file and are afterwards replaced with 40-character
hexadecimal blob object name which is based only on the particular file
contents.

This patch simplifes handling of $Id$ keywords by removing them since
they are not used anymore.