### PR TITLE
php8: backcompat defines of TSRMLS_CC, TSRMLS_DC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ php:
   - 7.4snapshot
   - nightly
 sudo: false
+addons:
+  apt:
+    packages:
+      - libonig-dev
 matrix:
   fast_finish: true
 env:

--- a/php_yaml_int.h
+++ b/php_yaml_int.h
@@ -52,6 +52,13 @@ extern "C" {
 	}                                    \
 } while (0)
 #endif
+
+#ifndef TSRMLS_DC
+#define TSRMLS_DC
+#endif
+#ifndef TSRMLS_CC
+#define TSRMLS_CC
+#endif
 /* }}} */
 
 /* {{{ ext/yaml types

--- a/tests/yaml_parse_file_002.phpt
+++ b/tests/yaml_parse_file_002.phpt
@@ -10,7 +10,13 @@ date.timezone=GMT
 yaml_parse_file(NULL);
 yaml_parse_file('');
 yaml_parse_file('invalid');
-yaml_parse_file();
+try {
+  // PHP7 emits a Warning here
+  yaml_parse_file();
+} catch (ArgumentCountError $e) {
+  // PHP8 raises this exception
+  echo "\nWarning: {$e->getMessage()} in " . __FILE__ . " on line 7\n";
+}
 --EXPECTF--
 Warning: yaml_parse_file(): Filename cannot be empty in %s on line %d
 


### PR DESCRIPTION
Local stub defines for TSRMLS_CC and TSRMLS_DC which have been removed
in php8 by php/php-src@bd73607b.