### PR TITLE
Fix #79494: The 64-bit YAML ext uses 32-bit signed integer arithmetics

### DIFF
--- a/emit.c
+++ b/emit.c
@@ -362,9 +362,9 @@ static int y_write_long(
 		omit_tag = 1;
 	}
 
-	res_size = snprintf(res, 0, "%ld", Z_LVAL_P(data));
+	res_size = snprintf(res, 0, ZEND_LONG_FMT, Z_LVAL_P(data));
 	res = (char*) emalloc(res_size + 1);
-	snprintf(res, res_size + 1, "%ld", Z_LVAL_P(data));
+	snprintf(res, res_size + 1, ZEND_LONG_FMT, Z_LVAL_P(data));
 
 	status = yaml_scalar_event_initialize(&event, NULL, tag,
 			(yaml_char_t *) res, strlen(res),

--- a/tests/bug_79494.phpt
+++ b/tests/bug_79494.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Test PECL bug #74949
+--SKIPIF--
+<?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--FILE--
+<?php
+$data = array (
+    'audio' =>
+    array (
+        'audioEnabled' =>
+        array (
+          0 => 132317787432502136,
+          1 => 0,
+    ),
+    'eveampGain' =>
+    array (
+          0 => 132316833510704299,
+          1 => 0.25,
+        ),
+    ),
+);
+
+print yaml_emit($data);
+?>
+--EXPECT--
+---
+audio:
+  audioEnabled:
+  - 132317787432502136
+  - 0
+  eveampGain:
+  - 132316833510704299
+  - 0.250000
+...


### PR DESCRIPTION
On LLP64 platforms, `zend_long` is a `long long`.  For best
portability, we use the `ZEND_LONG_FMT` format specifier instead.