### PR TITLE
Remove deprecated TSRM macros

### DIFF
--- a/php_yaml_int.h
+++ b/php_yaml_int.h
@@ -43,7 +43,7 @@ extern "C" {
 /* {{{ backcompat macros
 */
 #ifndef ZVAL_OPT_DEREF
-/* Taken from php-src/Zned/zend_types.h @ 95ff285 */
+/* Taken from php-src/Zend/zend_types.h @ 95ff285 */
 #define Z_OPT_ISREF(zval) (Z_OPT_TYPE(zval) == IS_REFERENCE)
 #define Z_OPT_ISREF_P(zval_p) Z_OPT_ISREF(*(zval_p))
 #define ZVAL_OPT_DEREF(z) do {           \
@@ -52,18 +52,11 @@ extern "C" {
 	}                                    \
 } while (0)
 #endif
-
-#ifndef TSRMLS_DC
-#define TSRMLS_DC
-#endif
-#ifndef TSRMLS_CC
-#define TSRMLS_CC
-#endif
 /* }}} */
 
 /* {{{ ext/yaml types
 */
-typedef void (*eval_scalar_func_t)(yaml_event_t event, HashTable *callbacks, zval *retval TSRMLS_DC);
+typedef void (*eval_scalar_func_t)(yaml_event_t event, HashTable *callbacks, zval *retval);
 
 typedef struct parser_state_s {
 	yaml_parser_t parser;
@@ -104,13 +97,6 @@ typedef struct y_emit_state_s {
 #define Y_SCALAR_IS_NAN         0x08
 #define Y_SCALAR_FORMAT_MASK    0x0F
 
-
-#if (PHP_MAJOR_VERSION > 5) || ((PHP_MAJOR_VERSION == 5) && (PHP_MINOR_VERSION >= 3))
-#	define ZEND_IS_CALLABLE(a,b,c) zend_is_callable((a), (b), (c) TSRMLS_CC)
-#else
-#	define ZEND_IS_CALLABLE(a,b,c) zend_is_callable((a), (b), (c))
-#endif
-
 #define STR_EQ(a, b)\
 	(a != NULL && b != NULL && 0 == strcmp(a, b))
 
@@ -136,16 +122,16 @@ typedef struct y_emit_state_s {
 
 /* {{{ ext/yaml prototypes
 */
-void php_yaml_read_all(parser_state_t *state, zend_long *ndocs, zval *retval TSRMLS_DC);
+void php_yaml_read_all(parser_state_t *state, zend_long *ndocs, zval *retval);
 
 void php_yaml_read_partial(
-		parser_state_t *state, zend_long pos, zend_long *ndocs, zval *retval TSRMLS_DC);
+		parser_state_t *state, zend_long pos, zend_long *ndocs, zval *retval);
 
 void eval_scalar(yaml_event_t event,
-		HashTable * callbacks, zval *retval TSRMLS_DC);
+		HashTable * callbacks, zval *retval);
 
 void eval_scalar_with_callbacks(
-		yaml_event_t event, HashTable *callbacks, zval *retval TSRMLS_DC);
+		yaml_event_t event, HashTable *callbacks, zval *retval);
 
 const char *detect_scalar_type(
 		const char *value, size_t length, const yaml_event_t *event);
@@ -162,7 +148,7 @@ int scalar_is_numeric(
 int scalar_is_timestamp(const char *value, size_t length);
 
 int php_yaml_write_impl(yaml_emitter_t *emitter, zval *data,
-		yaml_encoding_t encoding, HashTable *callbacks TSRMLS_DC);
+		yaml_encoding_t encoding, HashTable *callbacks);
 
 int php_yaml_write_to_buffer(
 		void *data, unsigned char *buffer, size_t size);

--- a/yaml.c
+++ b/yaml.c
@@ -37,7 +37,7 @@
 
 /* {{{ local prototypes
  */
-static int php_yaml_check_callbacks(HashTable *callbacks TSRMLS_DC);
+static int php_yaml_check_callbacks(HashTable *callbacks);
 
 static PHP_MINIT_FUNCTION(yaml);
 static PHP_MSHUTDOWN_FUNCTION(yaml);
@@ -279,7 +279,7 @@ static PHP_GINIT_FUNCTION(yaml)
 /* {{{ php_yaml_check_callbacks()
  * Validate user supplied callback array contents
  */
-static int php_yaml_check_callbacks(HashTable *callbacks TSRMLS_DC)
+static int php_yaml_check_callbacks(HashTable *callbacks)
 {
 	zval *entry;
 	zend_string *key;
@@ -288,15 +288,15 @@ static int php_yaml_check_callbacks(HashTable *callbacks TSRMLS_DC)
 		if (key) {
 			zend_string *name;
 
-			if (!ZEND_IS_CALLABLE(entry, 0, &name)) {
+			if (!zend_is_callable(entry, 0, &name)) {
 				if (name != NULL) {
-					php_error_docref(NULL TSRMLS_CC, E_WARNING,
+					php_error_docref(NULL, E_WARNING,
 							"Callback for tag '%s', '%s' is not valid",
 							key->val, name->val);
 					efree(name);
 
 				} else {
-					php_error_docref(NULL TSRMLS_CC, E_WARNING,
+					php_error_docref(NULL, E_WARNING,
 							"Callback for tag '%s' is not valid", key->val);
 				}
 				return FAILURE;
@@ -307,7 +307,7 @@ static int php_yaml_check_callbacks(HashTable *callbacks TSRMLS_DC)
 			}
 
 		} else {
-			php_error_docref(NULL TSRMLS_CC, E_NOTICE,
+			php_error_docref(NULL, E_NOTICE,
 					"Callback key should be a string");
 		}
 	} ZEND_HASH_FOREACH_END();
@@ -336,7 +336,7 @@ PHP_FUNCTION(yaml_parse)
 
 	YAML_G(timestamp_decoder) = NULL;
 
-	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC,
+	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(),
 					"S|lz/a/", &input, &pos, &zndocs,
 					&zcallbacks)) {
 		return;
@@ -344,7 +344,7 @@ PHP_FUNCTION(yaml_parse)
 
 	if (zcallbacks != NULL) {
 		state.callbacks = Z_ARRVAL_P(zcallbacks);
-		if (FAILURE == php_yaml_check_callbacks(state.callbacks TSRMLS_CC)) {
+		if (FAILURE == php_yaml_check_callbacks(state.callbacks)) {
 			RETURN_FALSE;
 		}
 
@@ -359,9 +359,9 @@ PHP_FUNCTION(yaml_parse)
 
 
 	if (pos < 0) {
-		php_yaml_read_all(&state, &ndocs, &yaml TSRMLS_CC);
+		php_yaml_read_all(&state, &ndocs, &yaml);
 	} else {
-		php_yaml_read_partial(&state, pos, &ndocs, &yaml TSRMLS_CC);
+		php_yaml_read_partial(&state, pos, &ndocs, &yaml);
 	}
 
 	yaml_parser_delete(&state.parser);
@@ -404,7 +404,7 @@ PHP_FUNCTION(yaml_parse_file)
 
 	YAML_G(timestamp_decoder) = NULL;
 
-	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC,
+	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(),
 					"s|lza/", &filename, &filename_len, &pos, &zndocs,
 					&zcallbacks)) {
 		return;
@@ -412,7 +412,7 @@ PHP_FUNCTION(yaml_parse_file)
 
 	if (zcallbacks != NULL) {
 		state.callbacks = Z_ARRVAL_P(zcallbacks);
-		if (FAILURE == php_yaml_check_callbacks(state.callbacks TSRMLS_CC)) {
+		if (FAILURE == php_yaml_check_callbacks(state.callbacks)) {
 			RETURN_FALSE;
 		}
 
@@ -438,10 +438,10 @@ PHP_FUNCTION(yaml_parse_file)
 	yaml_parser_set_input_file(&state.parser, fp);
 
 	if (pos < 0) {
-		php_yaml_read_all(&state, &ndocs, &yaml TSRMLS_CC);
+		php_yaml_read_all(&state, &ndocs, &yaml);
 
 	} else {
-		php_yaml_read_partial(&state, pos, &ndocs, &yaml TSRMLS_CC);
+		php_yaml_read_partial(&state, pos, &ndocs, &yaml);
 	}
 
 	yaml_parser_delete(&state.parser);
@@ -486,14 +486,14 @@ PHP_FUNCTION(yaml_parse_url)
 
 	YAML_G(timestamp_decoder) = NULL;
 
-	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC,
+	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(),
 				"s|lza/", &url, &url_len, &pos, &zndocs, &zcallbacks)) {
 		return;
 	}
 
 	if (zcallbacks != NULL) {
 		state.callbacks = Z_ARRVAL_P(zcallbacks);
-		if (FAILURE == php_yaml_check_callbacks(state.callbacks TSRMLS_CC)) {
+		if (FAILURE == php_yaml_check_callbacks(state.callbacks)) {
 			RETURN_FALSE;
 		}
 
@@ -517,9 +517,9 @@ PHP_FUNCTION(yaml_parse_url)
 	yaml_parser_set_input_string(&state.parser, (unsigned char *)input, size);
 
 	if (pos < 0) {
-		php_yaml_read_all(&state, &ndocs, &yaml TSRMLS_CC);
+		php_yaml_read_all(&state, &ndocs, &yaml);
 	} else {
-		php_yaml_read_partial(&state, pos, &ndocs, &yaml TSRMLS_CC);
+		php_yaml_read_partial(&state, pos, &ndocs, &yaml);
 	}
 
 	yaml_parser_delete(&state.parser);
@@ -553,14 +553,14 @@ PHP_FUNCTION(yaml_emit)
 	yaml_emitter_t emitter = { 0 };
 	smart_string str = { 0 };
 
-	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS()TSRMLS_CC, "z/|lla/",
+	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "z/|lla/",
 				&data, &encoding, &linebreak, &zcallbacks)) {
 		return;
 	}
 
 	if (zcallbacks != NULL) {
 		callbacks = Z_ARRVAL_P(zcallbacks);
-		if (FAILURE == php_yaml_check_callbacks(callbacks TSRMLS_CC)) {
+		if (FAILURE == php_yaml_check_callbacks(callbacks)) {
 			RETURN_FALSE;
 		}
 	}
@@ -577,7 +577,7 @@ PHP_FUNCTION(yaml_emit)
 
 	if (SUCCESS == php_yaml_write_impl(
 				&emitter, data, (yaml_encoding_t) encoding,
-				callbacks TSRMLS_CC)) {
+				callbacks)) {
 		RETVAL_STRINGL(str.c, str.len);
 
 	} else {
@@ -605,14 +605,14 @@ PHP_FUNCTION(yaml_emit_file)
 
 	yaml_emitter_t emitter = { 0 };
 
-	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Sz/|lla/",
+	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(), "Sz/|lla/",
 			&filename, &data, &encoding, &linebreak, &zcallbacks)) {
 		return;
 	}
 
 	if (zcallbacks != NULL) {
 		callbacks = Z_ARRVAL_P(zcallbacks);
-		if (FAILURE == php_yaml_check_callbacks(callbacks TSRMLS_CC)) {
+		if (FAILURE == php_yaml_check_callbacks(callbacks)) {
 			RETURN_FALSE;
 		}
 	}
@@ -639,7 +639,7 @@ PHP_FUNCTION(yaml_emit_file)
 	yaml_emitter_set_unicode(&emitter, YAML_ANY_ENCODING != encoding);
 
 	RETVAL_BOOL((SUCCESS == php_yaml_write_impl(
-			&emitter, data, YAML_ANY_ENCODING, callbacks TSRMLS_CC)));
+			&emitter, data, YAML_ANY_ENCODING, callbacks)));
 
 	yaml_emitter_delete(&emitter);
 	php_stream_close(stream);


### PR DESCRIPTION
Remove usage of the TSRMLS_CC and TSRMLS_DC macros which have been
removed from PHP 8.0 and a noop since PHP 7.0. Follow up to a8c3491.

Bug: 78353
Co-authored-by: Bryan Davis <bd808@bd808.com>