### PR TITLE
Fix for 32-bit

### DIFF
--- a/emit.c
+++ b/emit.c
@@ -506,9 +506,9 @@ static int y_write_array(
 	recursive_idx = y_search_recursive(state, (zend_ulong) ht);
 	if (-1 != recursive_idx) {
 		/* create anchor to refer to this structure */
-		anchor_size = snprintf(anchor, 0, "refid%ld", recursive_idx + 1);
+		anchor_size = snprintf(anchor, 0, "refid" ZEND_LONG_FMT, recursive_idx + 1);
 		anchor = (char*) emalloc(anchor_size + 1);
-		snprintf(anchor, anchor_size + 1, "refid%ld", recursive_idx + 1);
+		snprintf(anchor, anchor_size + 1, "refid" ZEND_LONG_FMT, recursive_idx + 1);
 
 #if PHP_VERSION_ID >= 70300
 		if (!(GC_FLAGS(ht) & GC_IMMUTABLE) && GC_IS_RECURSIVE(ht)) {

--- a/tests/bug_79494.phpt
+++ b/tests/bug_79494.phpt
@@ -22,13 +22,13 @@ $data = array (
 
 print yaml_emit($data);
 ?>
---EXPECT--
+--EXPECTF--
 ---
 audio:
   audioEnabled:
-  - 132317787432502136
+  - 13231778%s
   - 0
   eveampGain:
-  - 132316833510704299
+  - 13231683%s
   - 0.250000
 ...


### PR DESCRIPTION
1/ build warning

```
/builddir/build/BUILD/php-pecl-yaml-2.1.0/NTS/emit.c:509:45: warning: format '%ld' expects argument of type 'long int', but argument 4 has type 'int' [-Wformat=]
  509 |   anchor_size = snprintf(anchor, 0, "refid%ld", recursive_idx + 1);
      |                                           ~~^   ~~~~~~~~~~~~~~~~~
      |                                             |                 |
      |                                             long int          int
      |                                           %d
/builddir/build/BUILD/php-pecl-yaml-2.1.0/NTS/emit.c:511:45: warning: format '%ld' expects argument of type 'long int', but argument 4 has type 'int' [-Wformat=]
  511 |   snprintf(anchor, anchor_size + 1, "refid%ld", recursive_idx + 1);
      |                                           ~~^   ~~~~~~~~~~~~~~~~~
      |                                             |                 |
      |                                             long int          int
      |                                           %d

```

2/ test failure, related to float overflow

```
TEST 16/70 [tests/bug_79494.phpt]
========DIFF========
004+   - 132317787432502144.000000
004-   - 132317787432502136
007+   - 132316833510704304.000000
007-   - 132316833510704299
========DONE========
FAIL Test PECL bug #74949 [tests/bug_79494.phpt] 
```
