### PR TITLE
Skip 64-bit test on 32-bit arch

### DIFF
--- a/tests/bug_79494.phpt
+++ b/tests/bug_79494.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test PECL bug #74949
 --SKIPIF--
-<?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+<?php if(!extension_loaded('yaml') || PHP_INT_SIZE==4) die('skip yaml n/a'); ?>
 --FILE--
 <?php
 $data = array (


### PR DESCRIPTION
Follow-up to #79494 and https://github.com/php/pecl-file_formats-yaml/pull/39#issuecomment-619288979