### PR TITLE
Remove support for non-scalar mapping keys

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -70,6 +70,7 @@
     <file role="test" name="bug_74799.yaml" />
     <file role="test" name="bug_75029.phpt" />
     <file role="test" name="bug_76309.phpt" />
+    <file role="test" name="bug_77720.phpt" />
     <file role="test" name="bug_79494.phpt" />
     <file role="test" name="bug_parsing_alias.phpt" />
     <file role="test" name="yaml_001.phpt" />

--- a/tests/bug_64694.phpt
+++ b/tests/bug_64694.phpt
@@ -16,12 +16,12 @@ YAML;
 
 var_dump(yaml_parse($yaml_code));
 ?>
---EXPECT--
+--EXPECTF--
 array(1) {
   ["[a]"]=>
   int(1)
 }
-array(1) {
-  ["a:1:{i:0;s:1:"a";}"]=>
-  int(1)
+
+Warning: yaml_parse(): Illegal offset type array (line 1, column 7) in %s/bug_64694.php on line 12
+array(0) {
 }

--- a/tests/bug_77720.phpt
+++ b/tests/bug_77720.phpt
@@ -1,0 +1,295 @@
+--TEST--
+Test PECL bug #77720
+--SKIPIF--
+<?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--FILE--
+<?php
+$key_laughs = <<<YAML
+- &a ["lol","lol","lol","lol","lol","lol","lol","lol","lol"]
+- ? &b [{*a:1},{*a:1},{*a:1},{*a:1},{*a:1},{*a:1},{*a:1},{*a:1},{*a:}] : "foo"
+- ? &c [{*b:1},{*b:1},{*b:1},{*b:1},{*b:1},{*b:1},{*b:1},{*b:1},{*b:}] : "foo"
+- ? &d [{*c:1},{*c:1},{*c:1},{*c:1},{*c:1},{*c:1},{*c:1},{*c:1},{*c:}] : "foo"
+- ? &e [{*d:1},{*d:1},{*d:1},{*d:1},{*d:1},{*d:1},{*d:1},{*d:1},{*d:}] : "foo"
+- ? &f [{*e:1},{*e:1},{*e:1},{*e:1},{*e:1},{*e:1},{*e:1},{*e:1},{*e:}] : "foo"
+- ? &g [{*f:1},{*f:1},{*f:1},{*f:1},{*f:1},{*f:1},{*f:1},{*f:1},{*f:}] : "foo"
+- ? &h [{*g:1},{*g:1},{*g:1},{*g:1},{*g:1},{*g:1},{*g:1},{*g:1},{*g:}] : "foo"
+- ? &i [{*h:1},{*h:1},{*h:1},{*h:1},{*h:1},{*h:1},{*h:1},{*h:1},{*h:}] : "foo"
+- ? &j [{*i:1},{*i:1},{*i:1},{*i:1},{*i:1},{*i:1},{*i:1},{*i:1},{*i:}] : "foo"
+- ? &k [{*j:1},{*j:1},{*j:1},{*j:1},{*j:1},{*j:1},{*j:1},{*j:1},{*j:}] : "foo"
+YAML;
+var_dump(yaml_parse($key_laughs));
+?>
+--EXPECTF--
+
+Warning: yaml_parse(): Illegal offset type array (line 2, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 2, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 2, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 2, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 2, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 2, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 2, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 2, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 2, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 2, column 79) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 3, column 2) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 3, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 3, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 3, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 3, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 3, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 3, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 3, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 3, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 3, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 3, column 79) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 4, column 2) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 4, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 4, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 4, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 4, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 4, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 4, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 4, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 4, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 4, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 4, column 79) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 5, column 2) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 5, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 5, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 5, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 5, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 5, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 5, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 5, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 5, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 5, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 5, column 79) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 6, column 2) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 6, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 6, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 6, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 6, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 6, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 6, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 6, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 6, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 6, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 6, column 79) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 7, column 2) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 7, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 7, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 7, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 7, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 7, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 7, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 7, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 7, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 7, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 7, column 79) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 8, column 2) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 8, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 8, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 8, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 8, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 8, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 8, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 8, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 8, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 8, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 8, column 79) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 9, column 2) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 9, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 9, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 9, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 9, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 9, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 9, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 9, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 9, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 9, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 9, column 79) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 10, column 2) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 10, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 10, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 10, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 10, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 10, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 10, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 10, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 10, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 10, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 10, column 79) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 11, column 2) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 11, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 11, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 11, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 11, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 11, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 11, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 11, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 11, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 11, column 73) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 11, column 79) in %s/bug_77720.php on line 15
+
+Warning: yaml_parse(): Illegal offset type array (line 12, column 1) in %s/bug_77720.php on line 15
+array(11) {
+  [0]=>
+  array(9) {
+    [0]=>
+    string(3) "lol"
+    [1]=>
+    string(3) "lol"
+    [2]=>
+    string(3) "lol"
+    [3]=>
+    string(3) "lol"
+    [4]=>
+    string(3) "lol"
+    [5]=>
+    string(3) "lol"
+    [6]=>
+    string(3) "lol"
+    [7]=>
+    string(3) "lol"
+    [8]=>
+    string(3) "lol"
+  }
+  [1]=>
+  array(0) {
+  }
+  [2]=>
+  array(0) {
+  }
+  [3]=>
+  array(0) {
+  }
+  [4]=>
+  array(0) {
+  }
+  [5]=>
+  array(0) {
+  }
+  [6]=>
+  array(0) {
+  }
+  [7]=>
+  array(0) {
+  }
+  [8]=>
+  array(0) {
+  }
+  [9]=>
+  array(0) {
+  }
+  [10]=>
+  array(0) {
+  }
+}


### PR DESCRIPTION
The YAML 1.1 spec includes support for non-scalar keys in mappings. PHP
does not support non-scalar keys in its native array constructs.
Previously we handled this feature mismatch during YAML document parsing
by converting non-scalar key values to strings before using them as
keys. This approach provides some level of support for this
'interesting' part of the YAML specification, but it also leads to PHP
structures which cannot be cleanly round tripped back to a YAML document
matching the original input. It can also cause high runtime memory usage
for perverse YAML input.

Non-scalar keys will now generate a warning and omit the value from the
constructed array.

Bug: 64694
Bug: 77720