### PR TITLE
Use helpers from Zend to parse strings as numbers

### DIFF
--- a/detect.c
+++ b/detect.c
@@ -520,18 +520,18 @@ finish:
 				ptr++;
 			}
 
-			*lval = strtol(ptr, (char **) NULL, 2);
+			*lval = ZEND_STRTOL(ptr, (char **) NULL, 2);
 			if (*buf == '-') {
 				*lval *= -1L;
 			}
 			break;
 
 		case Y_SCALAR_IS_OCTAL:
-			*lval = strtol(buf, (char **) NULL, 8);
+			*lval = ZEND_STRTOL(buf, (char **) NULL, 8);
 			break;
 
 		case Y_SCALAR_IS_HEXADECIMAL:
-			*lval = strtol(buf, (char **) NULL, 16);
+			*lval = ZEND_STRTOL(buf, (char **) NULL, 16);
 			break;
 
 		case Y_SCALAR_IS_SEXAGECIMAL:
@@ -542,7 +542,7 @@ finish:
 			break;
 
 		default:
-			*lval = atol(buf);
+			ZEND_ATOL(*lval, buf);
 			break;
 		}
 
@@ -765,7 +765,7 @@ static zend_long eval_sexagesimal_l(zend_long lval, const char *sg, const char *
 	}
 
 	return eval_sexagesimal_l(
-			lval * 60 + strtol(sg, (char **) NULL, 10), ep, eos);
+			lval * 60 + ZEND_STRTOL(sg, (char **) NULL, 10), ep, eos);
 }
 /* }}} */
 
@@ -791,7 +791,7 @@ static double eval_sexagesimal_d(double dval, const char *sg, const char *eos)
 	}
 
 	return eval_sexagesimal_d(
-			dval * 60.0 + strtod(sg, (char **) NULL), ep, eos);
+			dval * 60.0 + zend_strtod(sg, (const char **) NULL), ep, eos);
 }
 /* }}} */
 

--- a/package.xml
+++ b/package.xml
@@ -32,6 +32,7 @@
  <license uri="http://www.opensource.org/licenses/mit-license.php">MIT</license>
  <notes>
   Bugs Fixed:
+  - #79567 Parsing long long values leads to truncation on LLP64 platforms (bd808)
   - #77720 Out of memory error when parsing yaml file (bd808)
   - [-Wformat=] issue on 32-bit (remicollet)
   - relax test on 32-bit (overflow to float) (remicollet)
@@ -68,6 +69,7 @@
     <file role="test" name="bug_76309.phpt" />
     <file role="test" name="bug_77720.phpt" />
     <file role="test" name="bug_79494.phpt" />
+    <file role="test" name="bug_79567.phpt" />
     <file role="test" name="bug_parsing_alias.phpt" />
     <file role="test" name="yaml_001.phpt" />
     <file role="test" name="yaml_002.phpt" />

--- a/php_yaml.h
+++ b/php_yaml.h
@@ -57,7 +57,9 @@ extern "C" {
 #include <Zend/zend_extensions.h>
 #include <Zend/zend_hash.h>
 #include <Zend/zend_interfaces.h>
+#include <Zend/zend_long.h>
 #include <Zend/zend_smart_str.h>
+#include <Zend/zend_strtod.h>
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/tests/bug_79567.phpt
+++ b/tests/bug_79567.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test PECL bug #79567
+--SKIPIF--
+<?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--FILE--
+<?php
+$data = [
+    'audioEnabled' => [
+        0 => 132317787432502136,
+        1 => 0,
+    ],
+];
+$yaml = yaml_emit($data);
+$result = yaml_parse($yaml);
+print $result == $data ? "Yes!\n" : "No...\n";
+?>
+--EXPECT--
+Yes!


### PR DESCRIPTION
Use ZEND_STRTOL, ZEND_ATOL, and zend_strtod helpers for better cross
platform portability.

Bug: 79567