### PR TITLE
Add AppVeyor CI integration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,50 @@
+image: Visual Studio 2017
+version: '{branch}.{build}'
+
+clone_folder: c:\projects\yaml
+
+install:
+  - ps: appveyor\install.ps1
+
+cache:
+  - c:\build-cache -> .appveyor.yml, appveyor\install.ps1
+
+environment:
+  BIN_SDK_VER: 2.2.0
+  matrix:
+    - PHP_VER: 7.2.30
+      ARCH: x64
+      TS: 1
+      VC: vc15
+      DEP: libyaml-0.1.7
+    - PHP_VER: 7.2.30
+      ARCH: x86
+      TS: 0
+      VC: vc15
+      DEP: libyaml-0.1.7
+    - PHP_VER: 7.3.17
+      ARCH: x64
+      TS: 1
+      VC: vc15
+      DEP: libyaml-0.1.7
+    - PHP_VER: 7.3.17
+      ARCH: x86
+      TS: 0
+      VC: vc15
+      DEP: libyaml-0.1.7
+    - PHP_VER: 7.4.5
+      ARCH: x64
+      TS: 1
+      VC: vc15
+      DEP: libyaml-0.1.7
+    - PHP_VER: 7.4.5
+      ARCH: x86
+      TS: 0
+      VC: vc15
+      DEP: libyaml-0.1.7
+
+build_script:
+  - ps: appveyor\build.ps1
+
+test_script:
+  - ps: appveyor\test.ps1

--- a/appveyor/build.ps1
+++ b/appveyor/build.ps1
@@ -1,0 +1,22 @@
+cd c:\projects\yaml
+echo "" | Out-File -Encoding "ASCII" task.bat
+echo "call phpize 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
+echo "call configure --with-php-build=c:\build-cache\deps --with-yaml --enable-debug-pack 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
+echo "nmake /nologo 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
+echo "exit %errorlevel%" | Out-File -Encoding "ASCII" -Append task.bat
+$here = (Get-Item -Path "." -Verbose).FullName
+$runner = 'c:\build-cache\php-sdk-' + $env:BIN_SDK_VER + '\phpsdk' + '-' + $env:VC + '-' + $env:ARCH + '.bat'
+$task = $here + '\task.bat'
+& $runner -t $task
+if (-not $?) {
+    throw "building failed with errorlevel $LastExitCode"
+}
+$dname = ''
+if ('x64' -eq  $env:ARCH) { $dname = $dname + 'x64\'}
+$dname = $dname + 'Release';
+if ('1' -eq $env:TS) { $dname = $dname + '_TS'}
+copy $dname\php_yaml.dll $env:PHP_PATH\ext\php_yaml.dll
+
+New-Item -Path $env:PHP_PATH\php.ini -Force
+Add-Content -Path $env:PHP_PATH\php.ini -Value 'extension_dir=ext'
+Add-Content -Path $env:PHP_PATH\php.ini -Value 'extension=php_yaml.dll'

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -1,0 +1,65 @@
+if (-not (Test-Path c:\build-cache)) {
+    mkdir c:\build-cache
+}
+$bname = 'php-sdk-' + $env:BIN_SDK_VER + '.zip'
+if (-not (Test-Path c:\build-cache\$bname)) {
+    Invoke-WebRequest "https://github.com/microsoft/php-sdk-binary-tools/archive/$bname" -OutFile "c:\build-cache\$bname"
+}
+$dname0 = 'php-sdk-binary-tools-php-sdk-' + $env:BIN_SDK_VER
+$dname1 = 'php-sdk-' + $env:BIN_SDK_VER
+if (-not (Test-Path c:\build-cache\$dname1)) {
+    7z x c:\build-cache\$bname -oc:\build-cache
+    move c:\build-cache\$dname0 c:\build-cache\$dname1
+}
+$ts_part = ''
+if ('0' -eq $env:TS) { $ts_part = '-nts' }
+$bname = 'php-devel-pack-' + $env:PHP_VER + $ts_part + '-Win32-' + $env:VC.toUpper() + '-' + $env:ARCH + '.zip'
+if (-not (Test-Path c:\build-cache\$bname)) {
+    Invoke-WebRequest "http://windows.php.net/downloads/releases/archives/$bname" -OutFile "c:\build-cache\$bname"
+    if (-not (Test-Path c:\build-cache\$bname)) {
+        Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
+    }
+}
+$dname0 = 'php-' + $env:PHP_VER + '-devel-' + $env:VC.toUpper() + '-' + $env:ARCH
+$dname1 = 'php-' + $env:PHP_VER + $ts_part + '-devel-' + $env:VC.toUpper() + '-' + $env:ARCH
+if (-not (Test-Path c:\build-cache\$dname1)) {
+    7z x c:\build-cache\$bname -oc:\build-cache
+    if ($dname0 -ne $dname1) {
+        move c:\build-cache\$dname0 c:\build-cache\$dname1
+    }
+}
+$env:PHP_DEVEL_PATH = 'c:\build-cache\' + $dname1
+$env:PATH = $env:PHP_DEVEL_PATH + ';' + $env:PATH
+
+$bname = 'php-' + $env:PHP_VER + $ts_part + '-Win32-' + $env:VC.toUpper() + '-' + $env:ARCH + '.zip'
+if (-not (Test-Path c:\build-cache\$bname)) {
+    Invoke-WebRequest "http://windows.php.net/downloads/releases/archives/$bname" -OutFile "c:\build-cache\$bname"
+    if (-not (Test-Path c:\build-cache\$bname)) {
+        Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
+    }
+}
+$dname = 'php-' + $env:PHP_VER + $ts_part + '-Win32-' + $env:VC.toUpper() + '-' + $env:ARCH
+if (-not (Test-Path c:\build-cache\$dname)) {
+    7z x c:\build-cache\$bname -oc:\build-cache\$dname
+}
+$env:PHP_PATH = 'c:\build-cache\' + $dname
+$env:PATH = $env:PHP_PATH + ';' + $env:PATH
+
+$bname = 'php-test-pack-' + $env:PHP_VER + '.zip'
+if (-not (Test-Path c:\build-cache\$bname)) {
+    Invoke-WebRequest "http://windows.php.net/downloads/releases/archives/$bname" -OutFile "c:\build-cache\$bname"
+    if (-not (Test-Path c:\build-cache\$bname)) {
+        Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
+    }
+}
+$dname = 'php-test-pack-' + $env:PHP_VER
+if (-not (Test-Path c:\build-cache\$dname)) {
+    7z x c:\build-cache\$bname -oc:\build-cache\$dname
+}
+$env:PHP_TEST_PATH = 'c:\build-cache\' + $dname
+
+$bname = $env:DEP + '-' + $env:VC.toUpper() + '-' + $env:ARCH + '.zip'
+if (-not (Test-Path c:\build-cache\$bname)) {
+    Invoke-WebRequest "http://windows.php.net/downloads/pecl/deps/$bname" -OutFile "c:\build-cache\$bname"
+    7z x c:\build-cache\$bname -oc:\build-cache\deps
+}

--- a/appveyor/test.ps1
+++ b/appveyor/test.ps1
@@ -1,0 +1,9 @@
+cd c:\projects\yaml
+
+$env:TEST_PHP_EXECUTABLE = $env:PHP_PATH + '\php.exe'
+$runner = $env:TEST_PHP_EXECUTABLE
+$run_tests= $env:PHP_TEST_PATH + '\run-test.php'
+& $runner $run_tests --show-diff tests
+if (-not $?) {
+    throw "testing failed with errorlevel $LastExitCode"
+}


### PR DESCRIPTION
There are 3 test failures to be expected. 2 of them are because of the hard-coded `/` in the expectations; you could either use `%e` instead, or just check for `%s` without the directory separator and the filename. The 3rd test fails likely due to int issues (might be https://bugs.php.net/79567).

Also, the build matrix in .appveyor.yml can be adapted according to your needs. Supporting master or older PHP versions (< 7.2) would require additional adjustments, though.