### PR TITLE
Fix memory leaks

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -366,8 +366,8 @@ void handle_document(parser_state_t *state, zval *retval)
 	/* assert that end event is next in stream */
 	if (NULL != retval && NEXT_EVENT() &&
 			YAML_DOCUMENT_END_EVENT != state->event.type) {
+		zval_ptr_dtor(retval);
 		ZVAL_UNDEF(retval);
-		//zval_ptr_dtor(&retval);
 		//retval = NULL;
 	}
 }
@@ -667,6 +667,7 @@ apply_filter(zval *zp, yaml_event_t event, HashTable *callbacks)
 					zval_ptr_dtor(tmp);
 					ZVAL_COPY_VALUE(tmp, &retval);
 				} else {
+					zval_ptr_dtor(zp);
 					ZVAL_COPY_VALUE(zp, &retval);
 				}
 			}

--- a/yaml.c
+++ b/yaml.c
@@ -293,13 +293,15 @@ static int php_yaml_check_callbacks(HashTable *callbacks)
 					php_error_docref(NULL, E_WARNING,
 							"Callback for tag '%s', '%s' is not valid",
 							key->val, name->val);
-					efree(name);
+					zend_string_release(name);
 
 				} else {
 					php_error_docref(NULL, E_WARNING,
 							"Callback for tag '%s' is not valid", key->val);
 				}
 				return FAILURE;
+			} else {
+				zend_string_release(name);
 			}
 
 			if (!memcmp(key->val, YAML_TIMESTAMP_TAG, sizeof(YAML_TIMESTAMP_TAG))) {


### PR DESCRIPTION
 * we release the `callable_names` retrieved by `zend_is_callable()`,
and also replace the erroneous `efree()`

 * we release the values returned from parse callbacks, if these
returned the given `$value`

 * we release the partially parsed value, if a document is invalid