### PR TITLE
Fix build on PHP 8 alpha 2 and later

### DIFF
--- a/emit.c
+++ b/emit.c
@@ -722,8 +722,8 @@ y_write_object_callback (
 	zend_string *str_key;
 
 	/* call the user function */
-	if (FAILURE == call_user_function_ex(EG(function_table), NULL,
-			callback, &zret, 1, argv, 0, NULL) ||
+	if (FAILURE == call_user_function(EG(function_table), NULL,
+			callback, &zret, 1, argv) ||
 			Z_TYPE_P(&zret) == IS_UNDEF) {
 		php_error_docref(NULL, E_WARNING,
 				"Failed to apply callback for class '%s'"

--- a/parse.c
+++ b/parse.c
@@ -643,7 +643,7 @@ apply_filter(zval *zp, yaml_event_t event, HashTable *callbacks)
 		ZVAL_LONG(&callback_args[2], 0);
 
 		/* call the user function */
-		callback_result = call_user_function_ex(EG(function_table), NULL, callback, &retval, 3, callback_args, 0, NULL);
+		callback_result = call_user_function(EG(function_table), NULL, callback, &retval, 3, callback_args);
 
 		/* cleanup our temp variables */
 		zval_ptr_dtor(&callback_args[1]);
@@ -846,7 +846,7 @@ void eval_scalar_with_callbacks(yaml_event_t event,
 		ZVAL_STRINGL(&argv[1], tag, strlen(tag));
 		ZVAL_LONG(&argv[2], event.data.scalar.style);
 
-		if (FAILURE == call_user_function_ex(EG(function_table), NULL, callback, retval, 3, argv, 0, NULL) || Z_TYPE_P(retval) == IS_UNDEF) {
+		if (FAILURE == call_user_function(EG(function_table), NULL, callback, retval, 3, argv) || Z_TYPE_P(retval) == IS_UNDEF) {
 			php_error_docref(NULL, E_WARNING,
 					"Failed to evaluate value for tag '%s'"
 					" with user defined function", tag);
@@ -898,8 +898,8 @@ eval_timestamp(zval **zpp, const char *ts, size_t ts_len)
 		ZVAL_STRINGL(&arg, ts, ts_len);
 		argv[0] = arg;
 
-		if (FAILURE == call_user_function_ex(EG(function_table), NULL, func,
-				&retval, 1, argv, 0, NULL) || Z_TYPE_P(&retval) == IS_UNDEF) {
+		if (FAILURE == call_user_function(EG(function_table), NULL, func,
+				&retval, 1, argv) || Z_TYPE_P(&retval) == IS_UNDEF) {
 			php_error_docref(NULL, E_WARNING,
 					"Failed to evaluate string '%s' as timestamp", ts);
 			if (func != NULL) {


### PR DESCRIPTION
Caused by https://github.com/php/php-src/commit/302933daea77663f5759b10accd1d0231393b24c

```
$ pecl install yaml

Starting to download yaml-2.1.0.tgz (39,439 bytes)
..........done: 39,439 bytes
8 source files, building
running: phpize8
Configuring for:
PHP Api Version:         20190128
Zend Module Api No:      20190128
Zend Extension Api No:   420190128
Please provide the prefix of libyaml installation [autodetect] : 
building in /tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0
running: /tmp/pear/temp/yaml/configure --with-php-config=/usr/bin/php-config8 --with-yaml
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for a sed that does not truncate output... /bin/sed
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
checking for cc... cc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether cc accepts -g... yes
checking for cc option to accept ISO C89... none needed
checking how to run the C preprocessor... cc -E
checking for icc... no
checking for suncc... no
checking for system library directory... lib
checking if compiler supports -R... no
checking if compiler supports -Wl,-rpath,... yes
checking build system type... x86_64-pc-linux-musl
checking host system type... x86_64-pc-linux-musl
checking target system type... x86_64-pc-linux-musl
checking for PHP prefix... /usr
checking for PHP includes... -I/usr/include/php8 -I/usr/include/php8/main -I/usr/include/php8/TSRM -I/usr/include/php8/Zend -I/usr/include/php8/ext -I/usr/include/php8/ext/date/lib
checking for PHP extension directory... /usr/lib/php8/modules
checking for PHP installed headers prefix... /usr/include/php8
checking if debug is enabled... no
checking if zts is enabled... no
checking for gawk... no
checking for nawk... no
checking for awk... awk
checking if awk is broken... no
checking whether to enable LibYAML suppot... yes, shared
checking for yaml headers... found in /usr
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking yaml.h usability... yes
checking yaml.h presence... yes
checking for yaml.h... yes
checking for a sed that does not truncate output... /bin/sed
checking for ld used by cc... /usr/x86_64-alpine-linux-musl/bin/ld
checking if the linker (/usr/x86_64-alpine-linux-musl/bin/ld) is GNU ld... yes
checking for /usr/x86_64-alpine-linux-musl/bin/ld option to reload object files... -r
checking for BSD-compatible nm... /usr/bin/nm -B
checking whether ln -s works... yes
checking how to recognize dependent libraries... pass_all
/tmp/pear/temp/yaml/configure: line 1: /usr/bin/file: not found
checking dlfcn.h usability... yes
checking dlfcn.h presence... yes
checking for dlfcn.h... yes
checking the maximum length of command line arguments... 98304
checking command to parse /usr/bin/nm -B output from cc object... ok
checking for objdir... .libs
checking for ar... ar
checking for ranlib... ranlib
checking for strip... strip
checking if cc supports -fno-rtti -fno-exceptions... no
checking for cc option to produce PIC... -fPIC
checking if cc PIC flag -fPIC works... yes
checking if cc static flag -static works... yes
checking if cc supports -c -o file.o... yes
checking whether the cc linker (/usr/x86_64-alpine-linux-musl/bin/ld) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... no

creating libtool
appending configuration tag "CXX" to libtool
configure: patching config.h.in
configure: creating ./config.status
config.status: creating config.h
running: make
/bin/sh /tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/libtool --mode=compile cc  -I. -I/tmp/pear/temp/yaml -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/include -I/tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/main -I/tmp/pear/temp/yaml -I/usr/include/php8 -I/usr/include/php8/main -I/usr/include/php8/TSRM -I/usr/include/php8/Zend -I/usr/include/php8/ext -I/usr/include/php8/ext/date/lib  -DHAVE_CONFIG_H  -g -O2   -c /tmp/pear/temp/yaml/yaml.c -o yaml.lo
mkdir .libs
 cc -I. -I/tmp/pear/temp/yaml -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/include -I/tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/main -I/tmp/pear/temp/yaml -I/usr/include/php8 -I/usr/include/php8/main -I/usr/include/php8/TSRM -I/usr/include/php8/Zend -I/usr/include/php8/ext -I/usr/include/php8/ext/date/lib -DHAVE_CONFIG_H -g -O2 -c /tmp/pear/temp/yaml/yaml.c  -fPIC -DPIC -o .libs/yaml.o
/bin/sh /tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/libtool --mode=compile cc  -I. -I/tmp/pear/temp/yaml -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/include -I/tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/main -I/tmp/pear/temp/yaml -I/usr/include/php8 -I/usr/include/php8/main -I/usr/include/php8/TSRM -I/usr/include/php8/Zend -I/usr/include/php8/ext -I/usr/include/php8/ext/date/lib  -DHAVE_CONFIG_H  -g -O2   -c /tmp/pear/temp/yaml/parse.c -o parse.lo
 cc -I. -I/tmp/pear/temp/yaml -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/include -I/tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/main -I/tmp/pear/temp/yaml -I/usr/include/php8 -I/usr/include/php8/main -I/usr/include/php8/TSRM -I/usr/include/php8/Zend -I/usr/include/php8/ext -I/usr/include/php8/ext/date/lib -DHAVE_CONFIG_H -g -O2 -c /tmp/pear/temp/yaml/parse.c  -fPIC -DPIC -o .libs/parse.o
/tmp/pear/temp/yaml/parse.c: In function 'apply_filter':
/tmp/pear/temp/yaml/parse.c:628:21: warning: implicit declaration of function 'call_user_function_ex'; did you mean '_call_user_function_ex'? [-Wimplicit-function-declaration]
  628 |   callback_result = call_user_function_ex(EG(function_table), NULL, callback, &retval, 3, callback_args, 0, NULL);
      |                     ^~~~~~~~~~~~~~~~~~~~~
      |                     _call_user_function_ex
/bin/sh /tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/libtool --mode=compile cc  -I. -I/tmp/pear/temp/yaml -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/include -I/tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/main -I/tmp/pear/temp/yaml -I/usr/include/php8 -I/usr/include/php8/main -I/usr/include/php8/TSRM -I/usr/include/php8/Zend -I/usr/include/php8/ext -I/usr/include/php8/ext/date/lib  -DHAVE_CONFIG_H  -g -O2   -c /tmp/pear/temp/yaml/emit.c -o emit.lo
 cc -I. -I/tmp/pear/temp/yaml -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/include -I/tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/main -I/tmp/pear/temp/yaml -I/usr/include/php8 -I/usr/include/php8/main -I/usr/include/php8/TSRM -I/usr/include/php8/Zend -I/usr/include/php8/ext -I/usr/include/php8/ext/date/lib -DHAVE_CONFIG_H -g -O2 -c /tmp/pear/temp/yaml/emit.c  -fPIC -DPIC -o .libs/emit.o
/tmp/pear/temp/yaml/emit.c: In function 'y_write_object_callback':
/tmp/pear/temp/yaml/emit.c:725:17: warning: implicit declaration of function 'call_user_function_ex'; did you mean '_call_user_function_ex'? [-Wimplicit-function-declaration]
  725 |  if (FAILURE == call_user_function_ex(EG(function_table), NULL,
      |                 ^~~~~~~~~~~~~~~~~~~~~
      |                 _call_user_function_ex
/bin/sh /tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/libtool --mode=compile cc  -I. -I/tmp/pear/temp/yaml -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/include -I/tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/main -I/tmp/pear/temp/yaml -I/usr/include/php8 -I/usr/include/php8/main -I/usr/include/php8/TSRM -I/usr/include/php8/Zend -I/usr/include/php8/ext -I/usr/include/php8/ext/date/lib  -DHAVE_CONFIG_H  -g -O2   -c /tmp/pear/temp/yaml/detect.c -o detect.lo
 cc -I. -I/tmp/pear/temp/yaml -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/include -I/tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/main -I/tmp/pear/temp/yaml -I/usr/include/php8 -I/usr/include/php8/main -I/usr/include/php8/TSRM -I/usr/include/php8/Zend -I/usr/include/php8/ext -I/usr/include/php8/ext/date/lib -DHAVE_CONFIG_H -g -O2 -c /tmp/pear/temp/yaml/detect.c  -fPIC -DPIC -o .libs/detect.o
/bin/sh /tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/libtool --mode=link cc -shared -DPHP_ATOM_INC -I/tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/include -I/tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/main -I/tmp/pear/temp/yaml -I/usr/include/php8 -I/usr/include/php8/main -I/usr/include/php8/TSRM -I/usr/include/php8/Zend -I/usr/include/php8/ext -I/usr/include/php8/ext/date/lib  -DHAVE_CONFIG_H  -g -O2    -o yaml.la -export-dynamic -avoid-version -prefer-pic -module -rpath /tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/modules  yaml.lo parse.lo emit.lo detect.lo -lyaml
cc -shared  .libs/yaml.o .libs/parse.o .libs/emit.o .libs/detect.o  -lyaml  -Wl,-soname -Wl,yaml.so -o .libs/yaml.so
creating yaml.la
(cd .libs && rm -f yaml.la && ln -s ../yaml.la yaml.la)
/bin/sh /tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/libtool --mode=install cp ./yaml.la /tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/modules
cp ./.libs/yaml.so /tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/modules/yaml.so
cp ./.libs/yaml.lai /tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/modules/yaml.la
PATH="$PATH:/sbin" ldconfig -n /tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/modules
----------------------------------------------------------------------
Libraries have been installed in:
   /tmp/pear/temp/pear-build-defaultuserPlpoEe/yaml-2.1.0/modules

If you ever happen to want to link against installed libraries
in a given directory, LIBDIR, you must either use libtool, and
specify the full pathname of the library, or use the `-LLIBDIR'
flag during linking and do at least one of the following:
   - add LIBDIR to the `LD_LIBRARY_PATH' environment variable
     during execution
   - add LIBDIR to the `LD_RUN_PATH' environment variable
     during linking
   - use the `-Wl,--rpath -Wl,LIBDIR' linker flag

See any operating system documentation about shared libraries for
more information, such as the ld(1) and ld.so(8) manual pages.
----------------------------------------------------------------------

Build complete.
Don't forget to run 'make test'.

running: make INSTALL_ROOT="/tmp/pear/temp/pear-build-defaultuserPlpoEe/install-yaml-2.1.0" install
Installing shared extensions:     /tmp/pear/temp/pear-build-defaultuserPlpoEe/install-yaml-2.1.0/usr/lib/php8/modules/
running: find "/tmp/pear/temp/pear-build-defaultuserPlpoEe/install-yaml-2.1.0" | xargs ls -dils
  27381      4 drwxr-xr-x    3 root     root          4096 Jul 11 15:16 /tmp/pear/temp/pear-build-defaultuserPlpoEe/install-yaml-2.1.0
  27408      4 drwxr-xr-x    3 root     root          4096 Jul 11 15:16 /tmp/pear/temp/pear-build-defaultuserPlpoEe/install-yaml-2.1.0/usr
  27409      4 drwxr-xr-x    3 root     root          4096 Jul 11 15:16 /tmp/pear/temp/pear-build-defaultuserPlpoEe/install-yaml-2.1.0/usr/lib
  27410      4 drwxr-xr-x    3 root     root          4096 Jul 11 15:16 /tmp/pear/temp/pear-build-defaultuserPlpoEe/install-yaml-2.1.0/usr/lib/php8
  27411      4 drwxr-xr-x    2 root     root          4096 Jul 11 15:16 /tmp/pear/temp/pear-build-defaultuserPlpoEe/install-yaml-2.1.0/usr/lib/php8/modules
  27406    328 -rwxr-xr-x    1 root     root        332240 Jul 11 15:16 /tmp/pear/temp/pear-build-defaultuserPlpoEe/install-yaml-2.1.0/usr/lib/php8/modules/yaml.so

Build process completed successfully
Installing '/usr/lib/php8/modules/yaml.so'
install ok: channel://pecl.php.net/yaml-2.1.0
configuration option "php_ini" is not set to php.ini location
You should add "extension=yaml.so" to php.ini
```
After build
```
$ php8 -dextension=yaml -m
PHP Warning:  PHP Startup: Unable to load dynamic library 'yaml' (tried: /usr/lib/php8/modules/yaml (Error loading shared library /usr/lib/php8/modules/yaml: No such file or directory), /usr/lib/php8/modules/yaml.so (Error relocating /usr/lib/php8/modules/yaml.so: call_user_function_ex: symbol not found)) in Unknown on line 0
[PHP Modules]
Core
date
filter
hash
json
libxml
openssl
pcre
readline
Reflection
SPL
standard
xml
zlib

[Zend Modules]
```