### PR TITLE
Use serialize_precision when encoding double values

### DIFF
--- a/dev-tools/test-all.sh
+++ b/dev-tools/test-all.sh
@@ -2,7 +2,7 @@
 
 rm .rbenv-version 2>/dev/null
 
-VERSIONS=$(phpenv versions --bare | grep -E '^(7|8|master)')
+VERSIONS=$(phpenv versions --bare | grep -E '^(7.[^0]|8|master)' | sort -V)
 SCRIPT_DIR=$(dirname $0)
 
 for v in $VERSIONS; do

--- a/emit.c
+++ b/emit.c
@@ -387,22 +387,20 @@ static int y_write_double(
 	yaml_event_t event;
 	int omit_tag = 0;
 	int status;
-	char *res = { 0 };
-	size_t res_size;
+	char res[PHP_DOUBLE_MAX_LENGTH];
 
 	if (NULL == tag) {
 		tag = (yaml_char_t *) YAML_FLOAT_TAG;
 		omit_tag = 1;
 	}
 
-	res_size = snprintf(res, 0, "%f", Z_DVAL_P(data));
-	res = (char*) emalloc(res_size + 1);
-	snprintf(res, res_size + 1, "%f", Z_DVAL_P(data));
+	// Bug 79866: let PHP determine output precision
+	php_gcvt(Z_DVAL_P(data), (int)PG(serialize_precision), '.', 'E', res);
 
 	status = yaml_scalar_event_initialize(&event, NULL, tag,
 			(yaml_char_t *) res, strlen(res),
 			omit_tag, omit_tag, YAML_PLAIN_SCALAR_STYLE);
-	efree(res);
+
 	if (!status) {
 		y_event_init_failed(&event);
 		return FAILURE;

--- a/package.xml
+++ b/package.xml
@@ -32,6 +32,7 @@
  <license uri="http://www.opensource.org/licenses/mit-license.php">MIT</license>
  <notes>
   Bugs Fixed:
+  - yaml_parse_file_002.phpt: Fix expectations for PHP 8.0.0beta1 (bd808)
   - Remove use of call_user_function_ex() for compat with PHP 8.0.0a2 (andypost)
   - Adjust test values for compat with 32bit platforms (bd808)
   - Fix memory leaks (cmb69)

--- a/package.xml
+++ b/package.xml
@@ -32,6 +32,7 @@
  <license uri="http://www.opensource.org/licenses/mit-license.php">MIT</license>
  <notes>
   Bugs Fixed:
+  - #79866 Use serialize_precision when encoding double values (bd808)
   - yaml_parse_file_002.phpt: Fix expectations for PHP 8.0.0beta1 (bd808)
   - Remove use of call_user_function_ex() for compat with PHP 8.0.0a2 (andypost)
   - Adjust test values for compat with 32bit platforms (bd808)
@@ -74,6 +75,7 @@
     <file role="test" name="bug_77720.phpt" />
     <file role="test" name="bug_79494.phpt" />
     <file role="test" name="bug_79567.phpt" />
+    <file role="test" name="bug_79866.phpt" />
     <file role="test" name="bug_parsing_alias.phpt" />
     <file role="test" name="yaml_001.phpt" />
     <file role="test" name="yaml_002.phpt" />

--- a/tests/bug_61923.phpt
+++ b/tests/bug_61923.phpt
@@ -2,6 +2,8 @@
 Test PECL bug #61923
 --SKIPIF--
 <?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--INI--
+serialize_precision=-1
 --FILE--
 <?php
 $yaml_code = <<<YAML
@@ -71,7 +73,7 @@ array(2) {
     float(67997.00037)
   }
 }
-string(162) "---
+string(161) "---
 strings:
 - "1:0"
 - "0:1"
@@ -89,6 +91,6 @@ numbers:
 - -3600
 - 1
 - 1
-- 67997.000370
+- 67997.00037
 ...
 "

--- a/tests/bug_76309.phpt
+++ b/tests/bug_76309.phpt
@@ -2,6 +2,8 @@
 Test PECL bug #76309
 --SKIPIF--
 <?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--INI--
+serialize_precision=-1
 --FILE--
 <?php
 echo yaml_emit([
@@ -20,7 +22,7 @@ a: "1.0"
 b: "2."
 c: "3"
 d: .
-e: 1.000000
-f: 2.000000
+e: 1
+f: 2
 g: 3
 ...

--- a/tests/bug_79494.phpt
+++ b/tests/bug_79494.phpt
@@ -2,6 +2,8 @@
 Test PECL bug #74949
 --SKIPIF--
 <?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--INI--
+serialize_precision=-1
 --FILE--
 <?php
 $data = array (
@@ -26,9 +28,9 @@ print yaml_emit($data);
 ---
 audio:
   audioEnabled:
-  - 13231778%s
+  - %r(132317787432502136|1\.3231778743250214E\+17)%r
   - 0
   eveampGain:
-  - 13231683%s
-  - 0.250000
+  - %r(132316833510704299|1\.323168335107043E\+17)%r
+  - 0.25
 ...

--- a/tests/bug_79866.phpt
+++ b/tests/bug_79866.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Test PECL bug #79866
+--SKIPIF--
+<?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--INI--
+precision=14
+serialize_precision=-1
+--FILE--
+<?php
+$floats = [
+  "0"            => 0,
+  "1"            => 1,
+  "-1"           => -1,
+  "2."           => 2.,
+  "2.0"          => 2.0,
+  "2.00"         => 2.00,
+  "2.000"        => 2.000,
+  "0.123456789"  => 0.123456789,
+  "-0.123456789" => -0.123456789,
+  "2.3e6"        => 2.3e6,
+  "-2.3e6"       => -2.3e6,
+  "2.3e-6"       => 2.3e-6,
+  "-2.3e-6"      => -2.3e-6,
+  "INF"          => INF,
+  "NAN"          => NAN,
+  "0.000021"     => 0.000021,
+];
+
+foreach( $floats as $idx => $float ) {
+  $float = floatval($float);
+  ob_start();
+  echo $float;
+  $native = ob_get_clean();
+
+  $expect = "--- {$native}\n...\n";
+  $got = yaml_emit($float);
+  if ( $got !== $expect ) {
+    echo "== FAIL! ${idx} ==\n";
+    echo "expected:\n{$expect}\n";
+    echo "got:{$got}\n";
+  }
+}
+?>
+--EXPECT--

--- a/tests/yaml_emit_001.phpt
+++ b/tests/yaml_emit_001.phpt
@@ -2,6 +2,8 @@
 yaml_emit - scalars
 --SKIPIF--
 <?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--INI--
+serialize_precision=-1
 --FILE--
 <?php
 var_dump(yaml_emit(null));
@@ -57,10 +59,10 @@ string(11) "--- 10
 string(12) "--- -10
 ...
 "
-string(19) "--- 123.456000
+string(16) "--- 123.456
 ...
 "
-string(20) "--- -123.456000
+string(17) "--- -123.456
 ...
 "
 string(14) "--- "yes"

--- a/tests/yaml_emit_002.phpt
+++ b/tests/yaml_emit_002.phpt
@@ -2,6 +2,8 @@
 yaml_emit - sequences
 --SKIPIF--
 <?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--INI--
+serialize_precision=-1
 --FILE--
 <?php
 $str = <<<EOD
@@ -65,14 +67,14 @@ var_dump(yaml_emit(array()));
 ?>
 --EXPECT--
 === Array of scalars ===
-string(610) "---
+string(604) "---
 - ~
 - true
 - false
 - 10
 - -10
-- 123.456000
-- -123.456000
+- 123.456
+- -123.456
 - "yes"
 - "no"
 - "~"

--- a/tests/yaml_emit_003.phpt
+++ b/tests/yaml_emit_003.phpt
@@ -2,6 +2,8 @@
 yaml_emit - mappings
 --SKIPIF--
 <?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--INI--
+serialize_precision=-1
 --FILE--
 <?php
 $addr = array(
@@ -41,7 +43,7 @@ $invoice = array (
 var_dump(yaml_emit($invoice));
 ?>
 --EXPECT--
-string(628) "---
+string(620) "---
 invoice: 34843
 date: 980208000
 bill-to:
@@ -73,8 +75,8 @@ product:
   quantity: 1
   description: Super Hoop
   price: 2392
-tax: 251.420000
-total: 4443.520000
+tax: 251.42
+total: 4443.52
 comments: Late afternoon is best. Backup contact is Nancy Billsmer @ 338-4338.
 ...
 "

--- a/tests/yaml_emit_006.phpt
+++ b/tests/yaml_emit_006.phpt
@@ -8,6 +8,7 @@ if(!extension_loaded('yaml')) die('skip yaml n/a');
 yaml.output_canonical=0
 yaml.output_indent=2
 yaml.output_width=80
+serialize_precision=-1
 --FILE--
 <?php
 $addr = array(
@@ -54,7 +55,7 @@ var_dump(yaml_emit($invoice));
 
 ?>
 --EXPECT--
-string(628) "---
+string(620) "---
 invoice: 34843
 date: 980208000
 bill-to:
@@ -86,13 +87,13 @@ product:
   quantity: 1
   description: Super Hoop
   price: 2392
-tax: 251.420000
-total: 4443.520000
+tax: 251.42
+total: 4443.52
 comments: Late afternoon is best. Backup contact is Nancy Billsmer @ 338-4338.
 ...
 "
 == CANONICAL ==
-string(1830) "---
+string(1822) "---
 !!map {
     ? !!str "invoice"
     : !!int "34843",
@@ -160,9 +161,9 @@ string(1830) "---
         },
     ],
     ? !!str "tax"
-    : !!float "251.420000",
+    : !!float "251.42",
     ? !!str "total"
-    : !!float "4443.520000",
+    : !!float "4443.52",
     ? !!str "comments"
     : !!str "Late afternoon is best. Backup
         contact is Nancy Billsmer @ 338-4338.",

--- a/tests/yaml_emit_file_basic.phpt
+++ b/tests/yaml_emit_file_basic.phpt
@@ -2,6 +2,8 @@
 Test Github pull request #1
 --SKIPIF--
 <?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--INI--
+serialize_precision=-1
 --FILE--
 <?php
 $addr = array(
@@ -50,7 +52,7 @@ unlink($temp_filename);
 ?>
 --EXPECT--
 bool(true)
-string(628) "---
+string(620) "---
 invoice: 34843
 date: 980208000
 bill-to:
@@ -82,8 +84,8 @@ product:
   quantity: 1
   description: Super Hoop
   price: 2392
-tax: 251.420000
-total: 4443.520000
+tax: 251.42
+total: 4443.52
 comments: Late afternoon is best. Backup contact is Nancy Billsmer @ 338-4338.
 ...
 "

--- a/tests/yaml_parse_file_002.phpt
+++ b/tests/yaml_parse_file_002.phpt
@@ -7,20 +7,32 @@ yaml.decode_timestamp=1
 date.timezone=GMT
 --FILE--
 <?php
-yaml_parse_file(NULL);
-yaml_parse_file('');
+try {
+  // PHP7 emits a Warning here
+  yaml_parse_file(NULL);
+} catch (ValueError $e) {
+  // PHP8 raises this exception
+  echo "\nWarning: yaml_parse_file(): {$e->getMessage()} in " . __FILE__ . " on line 4\n";
+}
+try {
+  // PHP7 emits a Warning here
+  yaml_parse_file('');
+} catch (ValueError $e) {
+  // PHP8 raises this exception
+  echo "\nWarning: yaml_parse_file(): {$e->getMessage()} in " . __FILE__ . " on line 11\n";
+}
 yaml_parse_file('invalid');
 try {
   // PHP7 emits a Warning here
   yaml_parse_file();
 } catch (ArgumentCountError $e) {
   // PHP8 raises this exception
-  echo "\nWarning: {$e->getMessage()} in " . __FILE__ . " on line 7\n";
+  echo "\nWarning: {$e->getMessage()} in " . __FILE__ . " on line 19\n";
 }
 --EXPECTF--
-Warning: yaml_parse_file(): Filename cannot be empty in %s on line %d
+Warning: yaml_parse_file(): %r(Filename|Path)%r cannot be empty in %s on line %d
 
-Warning: yaml_parse_file(): Filename cannot be empty in %s on line %d
+Warning: yaml_parse_file(): %r(Filename|Path)%r cannot be empty in %s on line %d
 
 Warning: yaml_parse_file(invalid): %r[Ff]%railed to open stream: No such file or directory in %s on line %d
 


### PR DESCRIPTION
Switch output encoding of double values from a naive usage of
`snprintf` with no explicit precision to the improved `php_gcvt` with
INI set serialize_precision. This brings our implementation in line with
that of the json extension and makes most (all?) doubles output the same
as `echo`.

Bug: 79866