### PR TITLE
Fix #80324: Segfault in YAML with anonymous functions

### DIFF
--- a/tests/bug80324.phpt
+++ b/tests/bug80324.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Bug #80324 (Segfault in YAML with anonymous functions)
+--SKIPIF--
+<?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--FILE--
+<?php
+$yaml = <<<YAML
+- !env ENV
+- !path PATH
+YAML;
+
+$result = yaml_parse($yaml, 0, $ndocs, array(
+    '!env' => function ($str) {return $str;},
+    '!path' => function ($str) {return $str;},
+  ));
+
+var_dump($result);
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  string(3) "ENV"
+  [1]=>
+  string(4) "PATH"
+}

--- a/yaml.c
+++ b/yaml.c
@@ -304,7 +304,7 @@ static int php_yaml_check_callbacks(HashTable *callbacks)
 				zend_string_release(name);
 			}
 
-			if (!memcmp(key->val, YAML_TIMESTAMP_TAG, sizeof(YAML_TIMESTAMP_TAG))) {
+			if (zend_string_equals_literal(key, YAML_TIMESTAMP_TAG)) {
 				YAML_G(timestamp_decoder) = entry;
 			}
 


### PR DESCRIPTION
We must not assume that `key->val` is `sizeof(YAML_TIMESTAMP_TAG)` long
or longer.  Actually, `zend_string_equals_literal()` (available as of
PHP 7.0.0) does exactly what we want.