### PR TITLE
Fix memory leak in handle_mapping()

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -403,6 +403,7 @@ void handle_mapping(parser_state_t *state, zval *retval)
 		if (Z_TYPE(value) == IS_UNDEF) {
 			yaml_event_delete(&src_event);
 			yaml_event_delete(&key_event);
+			zval_ptr_dtor(&key);
 			return;
 		}
 


### PR DESCRIPTION
We must not forget to release the previously created array in case we
return early due to an undefined value.

This memory leak could be observed when running `yaml_parse_003.phpt`
and `yaml_parse_004.phpt` under a debug build or with a leak checker.