### PR TITLE
Fix build on PHP 8.1 beta1

### DIFF
--- a/detect.c
+++ b/detect.c
@@ -542,7 +542,11 @@ finish:
 			break;
 
 		default:
+#if PHP_VERSION_ID >= 80100
+			*lval = ZEND_ATOL(buf);
+#else
 			ZEND_ATOL(*lval, buf);
+#endif
 			break;
 		}
 


### PR DESCRIPTION
Build fails  because 8.1 changed `PHP_ATOL()` https://github.com/php/php-src/commit/efbb2198d4e5a01167d1a8c2937b848f75ac4d19
