### PR TITLE
Fix test for PHP 8.2

### DIFF
--- a/tests/bug_79866.phpt
+++ b/tests/bug_79866.phpt
@@ -35,7 +35,7 @@ foreach( $floats as $idx => $float ) {
   $expect = "--- {$native}\n...\n";
   $got = yaml_emit($float);
   if ( $got !== $expect ) {
-    echo "== FAIL! ${idx} ==\n";
+    echo "== FAIL! {$idx} ==\n";
     echo "expected:\n{$expect}\n";
     echo "got:{$got}\n";
   }


### PR DESCRIPTION
```
TEST 19/74 [tests/bug_79866.phpt]
========DIFF========
001+ Deprecated: Using ${var} in strings is deprecated, use {$var} instead in .../yaml-2.2.2/tests/bug_79866.php on line 30
001- 
========DONE========
FAIL Test PECL bug #79866 [tests/bug_79866.phpt] 
```