### PR TITLE
Fixed memory release on error handling

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -467,6 +467,7 @@ void handle_mapping(parser_state_t *state, zval *retval)
 					state->parser.mark.line + 1,
 					state->parser.mark.column + 1
 				);
+				zval_ptr_dtor(&value);
 				break;
 			}
 		}
@@ -518,8 +519,10 @@ void handle_sequence (parser_state_t *state, zval *retval) {
 	}
 
 	if (YAML_SEQUENCE_END_EVENT != state->event.type) {
-		//TODO Sean-Der
+		zval_ptr_dtor(retval);
 		ZVAL_UNDEF(retval);
+		goto done;
+		//TODO Sean-Der
 		//zval_ptr_dtor(&retval);
 		//retval = NULL;
 	}
@@ -528,13 +531,15 @@ void handle_sequence (parser_state_t *state, zval *retval) {
 		/* apply callbacks to the collected node */
 		if (Y_FILTER_FAILURE == apply_filter(
 				retval, src_event, state->callbacks)) {
-			//TODO Sean-Der
+			zval_ptr_dtor(&retval);
 			ZVAL_UNDEF(retval);
-			//zval_ptr_dtor(&retval);
+			goto done;
+			//TODO Sean-Der
 			//retval = NULL;
 		}
 	}
 
+done:
 	yaml_event_delete(&src_event);
 }
 /* }}} */


### PR DESCRIPTION
Running tests with PHP built with `'--enable-debug' '--enable-debug-assertions'`, we discovered a few places when memory doesn't get released after an error.

Problematic tests:

**tests/bug_77720.phpt**
```
/opt/phpbuild/include/php/Zend/zend_string.h(144) :  Freeing 0x000000010a404c40 (32 bytes), script=/Users/mikhailgalanin/src/pecl-file_formats-yaml/tests/bug_77720.php
Last leak repeated 9 times

```

**tests/yaml_parse_006.out**
```
[Fri Feb 24 11:28:03 2023]  Script:  '/Users/mikhailgalanin/src/pecl-file_formats-yaml/tests/yaml_parse_006.php'
/Users/mikhailgalanin/repos/php-src/Zend/zend_hash.c(278) :  Freeing 0x0000000106601600 (56 bytes), script=/Users/mikhailgalanin/src/pecl-file_formats-yaml/tests/yaml_parse_006.php
Last leak repeated 1 time
