### PR TITLE
Fix #75: Handle zndocs/ndocs correctly

### DIFF
--- a/tests/yaml_parse_file_003.phpt
+++ b/tests/yaml_parse_file_003.phpt
@@ -1,0 +1,11 @@
+-TEST--
+yaml_parse_file - ndocs
+--SKIPIF--
+<?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--FILE--
+<?php
+$nd = 0;
+yaml_parse_file(__DIR__ . '/yaml_parse_file_003.yaml', -1, $nd);
+var_dump($nd);
+--EXPECT--
+int(2)

--- a/tests/yaml_parse_file_003.phpt
+++ b/tests/yaml_parse_file_003.phpt
@@ -1,4 +1,4 @@
--TEST--
+--TEST--
 yaml_parse_file - ndocs
 --SKIPIF--
 <?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>

--- a/tests/yaml_parse_file_003.yaml
+++ b/tests/yaml_parse_file_003.yaml
@@ -1,0 +1,7 @@
+---
+This is a front-matter
+---
+doc:
+  - prop1: val1
+    prop2: val2
+...

--- a/yaml.c
+++ b/yaml.c
@@ -407,7 +407,7 @@ PHP_FUNCTION(yaml_parse_file)
 	YAML_G(timestamp_decoder) = NULL;
 
 	if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS(),
-					"s|lza/", &filename, &filename_len, &pos, &zndocs,
+					"s|lz/a/", &filename, &filename_len, &pos, &zndocs,
 					&zcallbacks)) {
 		return;
 	}
@@ -451,7 +451,7 @@ PHP_FUNCTION(yaml_parse_file)
 
 	if (zndocs != NULL) {
 		/* copy document count to var user sent in */
-		zval_dtor(zndocs);
+		zval_ptr_dtor(zndocs);
 		ZVAL_LONG(zndocs, ndocs);
 	}
 


### PR DESCRIPTION
Just changing the handling, that is param handling of ndocs and dtor call for zndocs, in yaml_parse_file to that in yaml_parse. That fixes #75 for me.