### PR TITLE
ci: Add matcher for GCC errors & warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,6 +109,8 @@ jobs:
         run: phpize
       - name: Configure build
         run: configure --with-yaml --with-php-build=..\deps --with-prefix=${{ steps.setup-php.outputs.prefix }}
+      - name: Report gcc problems
+        uses: ammaraskar/gcc-problem-matcher@master
       - name: Build
         run: nmake /D /P
       - name: Run tests


### PR DESCRIPTION
Add the ammaraskar/gcc-problem-matcher@master helper to add gcc error and warning messages as code review comments.