### PR TITLE
avoid  unexpected NAN value was coerced to string

### DIFF
--- a/tests/bug_79866.phpt
+++ b/tests/bug_79866.phpt
@@ -29,7 +29,7 @@ $floats = [
 foreach( $floats as $idx => $float ) {
   $float = floatval($float);
   ob_start();
-  echo $float;
+  @print_r($float);
   $native = ob_get_clean();
 
   $expect = "--- {$native}\n...\n";


### PR DESCRIPTION
See https://wiki.php.net/rfc/warnings-php-8-5#coercing_nan_to_other_types

```
                                                 
========DIFF========
001+ == FAIL! NAN ==
002+ expected:
003+ --- 
004+ Warning: unexpected NAN value was coerced to string in /work/GIT/pecl-and-ext/yaml/tests/bug_79866.php on line 24
005+ NAN
006+ ...
     
008+ got:--- NAN
009+ ...
========DONE========
FAIL Test PECL bug #79866 [tests/bug_79866.phpt] 

```