### PR TITLE
Ignore null array offset warnings in explicit null tests

### DIFF
--- a/tests/bug_64019.phpt
+++ b/tests/bug_64019.phpt
@@ -2,6 +2,9 @@
 Test PECL bug #64019
 --SKIPIF--
 <?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--INI--
+; Ignore Deprecated: Using null as an array offset is deprecated...
+error_reporting = E_ALL & ~E_DEPRECATED
 --FILE--
 <?php
 $yaml_code = <<<YAML

--- a/tests/yaml_parse_spec_null.phpt
+++ b/tests/yaml_parse_spec_null.phpt
@@ -2,6 +2,9 @@
 Yaml 1.1 Spec - null
 --SKIPIF--
 <?php if(!extension_loaded('yaml')) die('skip yaml n/a'); ?>
+--INI--
+; Ignore Deprecated: Using null as an array offset is deprecated...
+error_reporting = E_ALL & ~E_DEPRECATED
 --FILE--
 <?php
   var_dump(yaml_parse('


### PR DESCRIPTION
Ignore warnings while running tests involving explicit null handling. This avoids false test failures triggered by PHP 8.5 deprecation warnings.

Bug: #97