### PR TITLE
Validate merge key values revisited

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -431,6 +431,8 @@ void handle_mapping(parser_state_t *state, zval *retval)
 				ZEND_HASH_FOREACH_VAL(HASH_OF(valptr), zvalp) {
 					if (Z_ISREF_P(zvalp)) {
 						ZVAL_DEREF(zvalp);
+					}
+					if (Z_TYPE_P(zvalp) == IS_ARRAY) {
 						zend_hash_merge(
 								Z_ARRVAL_P(arrval), Z_ARRVAL_P(zvalp),
 								zval_add_ref, 0);

--- a/tests/bug_74886.phpt
+++ b/tests/bug_74886.phpt
@@ -12,13 +12,25 @@ var_dump(yaml_parse('
   << : [ 0x7FFFFFFF ]
 - # scalar in sequence len 2
   << : [ *REF, 0x7FFFFFFF ]
+
+- &SCALAR_REF some-string
+- # scalar ref
+  << : *SCALAR_REF
+- # scalar ref in sequence len 1
+  << : [ *SCALAR_REF ]
+- # scalar ref in sequence len 2
+  << : [ *REF, *SCALAR_REF ]
 '));
 ?>
 --EXPECTF--
 Warning: yaml_parse(): expected a mapping for merging, but found scalar (line 6, column 22) in %sbug_74886.php on line 2
 
 Warning: yaml_parse(): expected a mapping for merging, but found scalar (line 8, column 28) in %sbug_74886.php on line 2
-array(4) {
+
+Warning: yaml_parse(): expected a mapping for merging, but found scalar (line 14, column 23) in %sbug_74886.php on line 2
+
+Warning: yaml_parse(): expected a mapping for merging, but found scalar (line 16, column 29) in %sbug_74886.php on line 2
+array(8) {
   [0]=>
   array(1) {
     ["x"]=>
@@ -33,6 +45,21 @@ array(4) {
   array(0) {
   }
   [3]=>
+  array(1) {
+    ["x"]=>
+    int(1)
+  }
+  [4]=>
+  &string(11) "some-string"
+  [5]=>
+  array(1) {
+    ["<<"]=>
+    &string(11) "some-string"
+  }
+  [6]=>
+  array(0) {
+  }
+  [7]=>
   array(1) {
     ["x"]=>
     int(1)


### PR DESCRIPTION
Ensure that aliases used in merge key mappings reference arrays.

Bug: 74886